### PR TITLE
Fixes CVE-2025-2750: out of bounds write by assigning to wrong array …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,20 +50,21 @@ CMAKE_MINIMUM_REQUIRED( VERSION 3.22 )
 # M3D format import support (assimp integration no longer supported by M3D format author)
 # User may override these in their CMake script to provide M3D import/export support
 # (M3D importer/exporter was disabled for assimp release 5.1 or later)
-option(ASSIMP_BUILD_M3D_IMPORTER "Enable M3D file import" off)
-option(ASSIMP_BUILD_M3D_EXPORTER "Enable M3D file export" off)
+OPTION(ASSIMP_BUILD_M3D_IMPORTER "Enable M3D file import" off)
+OPTION(ASSIMP_BUILD_M3D_EXPORTER "Enable M3D file export" off)
 
 # Experimental USD importer: disabled, need to opt-in
 # Note: assimp github PR automatic checks will fail the PR due to compiler warnings in
 # the external, 3rd party tinyusdz code which isn't technically part of the PR since it's
 # auto-cloned during build; so MUST disable the feature or the PR will be rejected
-option(ASSIMP_BUILD_USD_IMPORTER "Enable USD file import" off)
-option(ASSIMP_BUILD_USD_VERBOSE_LOGS "Enable verbose USD import debug logging" off)
+OPTION(ASSIMP_BUILD_USD_IMPORTER "Enable USD file import" off)
+OPTION(ASSIMP_BUILD_USD_VERBOSE_LOGS "Enable verbose USD import debug logging" off)
 
 # VRML (.wrl/.x3dv) file import support by leveraging X3D importer and 3rd party file
 # format converter to convert .wrl/.x3dv files to X3D-compatible .xml
 # (Need to make this opt-in because 3rd party code triggers lots of CI code quality warnings)
-option(ASSIMP_BUILD_VRML_IMPORTER "Enable VRML (.wrl/.x3dv) file import" off)
+OPTION(ASSIMP_BUILD_VRML_IMPORTER "Enable VRML (.wrl/.x3dv) file import" off)
+
 #--------------------------------------------------------------------------------#
 #                  Internal impl for optional model formats
 #--------------------------------------------------------------------------------#
@@ -83,13 +84,13 @@ endif () # if (not ASSIMP_BUILD_VRML_IMPORTER)
 
 option(ASSIMP_BUILD_USE_CCACHE "Use ccache to speed up compilation." on)
 
-if(ASSIMP_BUILD_USE_CCACHE)
+IF(ASSIMP_BUILD_USE_CCACHE)
   find_program(CCACHE_PATH ccache)
-  if (CCACHE_PATH)
+  IF (CCACHE_PATH)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PATH})
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PATH})
-  endif()
-endif()
+  ENDIF()
+ENDIF()
 
 # Toggles the use of the hunter package manager
 option(ASSIMP_HUNTER_ENABLED "Enable Hunter package manager support" OFF)
@@ -100,7 +101,7 @@ IF(ASSIMP_HUNTER_ENABLED)
     URL "https://github.com/cpp-pm/hunter/archive/v0.25.8.tar.gz"
     SHA1 "26c79d587883ec910bce168e25f6ac4595f97033"
   )
-  add_definitions(-DASSIMP_USE_HUNTER)
+  ADD_DEFINITIONS(-DASSIMP_USE_HUNTER)
 ENDIF()
 
 PROJECT(Assimp VERSION 6.0.1)
@@ -480,20 +481,20 @@ ENDIF()
 set(GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 IF(ASSIMP_HUNTER_ENABLED)
-  set(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
-  set(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-hunter-config.cmake.in")
-  set(NAMESPACE "${PROJECT_NAME}::")
-  set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-  set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
-  set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
+  SET(CONFIG_INSTALL_DIR "lib/cmake/${PROJECT_NAME}")
+  SET(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-hunter-config.cmake.in")
+  SET(NAMESPACE "${PROJECT_NAME}::")
+  SET(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+  SET(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
+  SET(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME}Config.cmake")
 ELSE()
-  set(CONFIG_INSTALL_DIR "${ASSIMP_LIB_INSTALL_DIR}/cmake/assimp-${ASSIMP_VERSION_MAJOR}.${ASSIMP_VERSION_MINOR}")
-  set(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-plain-config.cmake.in")
+  SET(CONFIG_INSTALL_DIR "${ASSIMP_LIB_INSTALL_DIR}/cmake/assimp-${ASSIMP_VERSION_MAJOR}.${ASSIMP_VERSION_MINOR}")
+  SET(CMAKE_CONFIG_TEMPLATE_FILE "cmake-modules/assimp-plain-config.cmake.in")
   string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWERCASE)
-  set(NAMESPACE "${PROJECT_NAME_LOWERCASE}::")
-  set(TARGETS_EXPORT_NAME "${PROJECT_NAME_LOWERCASE}Targets")
-  set(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME_LOWERCASE}ConfigVersion.cmake")
-  set(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME_LOWERCASE}Config.cmake")
+  SET(NAMESPACE "${PROJECT_NAME_LOWERCASE}::")
+  SET(TARGETS_EXPORT_NAME "${PROJECT_NAME_LOWERCASE}Targets")
+  SET(VERSION_CONFIG "${GENERATED_DIR}/${PROJECT_NAME_LOWERCASE}ConfigVersion.cmake")
+  SET(PROJECT_CONFIG "${GENERATED_DIR}/${PROJECT_NAME_LOWERCASE}Config.cmake")
 ENDIF()
 
 set(INCLUDE_INSTALL_DIR "include")
@@ -510,20 +511,20 @@ configure_package_config_file(
     INSTALL_DESTINATION "${CONFIG_INSTALL_DIR}"
 )
 
-if(ASSIMP_INSTALL)
-  install(
+IF(ASSIMP_INSTALL)
+  INSTALL(
       FILES "${PROJECT_CONFIG}" "${VERSION_CONFIG}"
       DESTINATION "${CONFIG_INSTALL_DIR}"
       COMPONENT ${LIBASSIMP-DEV_COMPONENT}
   )
 
-  install(
+  INSTALL(
       EXPORT "${TARGETS_EXPORT_NAME}"
       NAMESPACE "${NAMESPACE}"
       DESTINATION "${CONFIG_INSTALL_DIR}"
       COMPONENT ${LIBASSIMP-DEV_COMPONENT}
   )
-endif()
+ENDIF()
 
 IF( ASSIMP_BUILD_DOCS )
   ADD_SUBDIRECTORY(doc)
@@ -536,9 +537,9 @@ IF(ASSIMP_HUNTER_ENABLED)
   find_package(ZLIB CONFIG REQUIRED)
 
   add_definitions(-DASSIMP_BUILD_NO_OWN_ZLIB)
-  set(ZLIB_FOUND TRUE)
-  set(ZLIB_LIBRARIES ZLIB::zlib)
-  set(ASSIMP_BUILD_MINIZIP TRUE)
+  SET(ZLIB_FOUND TRUE)
+  SET(ZLIB_LIBRARIES ZLIB::zlib)
+  SET(ASSIMP_BUILD_MINIZIP TRUE)
 ELSE()
   # If the zlib is already found outside, add an export in case assimpTargets can't find it.
   IF( ZLIB_FOUND AND ASSIMP_INSTALL)
@@ -565,8 +566,8 @@ ELSE()
     #		https://github.com/madler/zlib/issues/41#issuecomment-125848075
     # Also prevents these options from "polluting" the cmake options if assimp is being
     # included as a submodule.
-    set( ASM686 FALSE CACHE INTERNAL "Override ZLIB flag to turn off assembly" FORCE )
-    set( AMD64 FALSE CACHE INTERNAL "Override ZLIB flag to turn off assembly" FORCE )
+    SET(ASM686 FALSE CACHE INTERNAL "Override ZLIB flag to turn off assembly" FORCE )
+    SET(AMD64 FALSE CACHE INTERNAL "Override ZLIB flag to turn off assembly" FORCE )
 
     # compile from sources
     ADD_SUBDIRECTORY(contrib/zlib)
@@ -589,7 +590,7 @@ IF( NOT IOS )
 ELSE ()
   IF( NOT BUILD_SHARED_LIBS )
     IF( NOT ASSIMP_BUILD_MINIZIP )
-      use_pkgconfig(UNZIP minizip)
+      USE_PKGCONFIG(UNZIP minizip)
     ENDIF()
   ENDIF ()
 ENDIF ()
@@ -672,48 +673,48 @@ IF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
       "${C4D_LIB_BASE_PATH}/release/libcinewarelib.a"
       "${C4D_LIB_BASE_PATH}/release/libjpeglib.a"
     )
-  ELSE ()
+  ELSE()
     MESSAGE( FATAL_ERROR
       "C4D is currently only available on Windows and macOS with Cineware SDK installed in contrib/Cineware"
     )
-  ENDIF ()
+  ENDIF()
 ELSE ()
   ADD_DEFINITIONS( -DASSIMP_BUILD_NO_C4D_IMPORTER )
 ENDIF ()
 
-if(ASSIMP_BUILD_DRACO_STATIC)
-  set(ASSIMP_BUILD_DRACO ON)
-endif()
+IF(ASSIMP_BUILD_DRACO_STATIC)
+  SET(ASSIMP_BUILD_DRACO ON)
+ENDIF()
 
 # Draco requires cmake 3.12
 IF (DEFINED CMAKE_VERSION AND "${CMAKE_VERSION}" VERSION_LESS "3.12")
-  message(NOTICE "draco requires cmake 3.12 or newer, cmake is ${CMAKE_VERSION} . Draco is disabled")
+  MESSAGE(NOTICE "draco requires cmake 3.12 or newer, cmake is ${CMAKE_VERSION} . Draco is disabled")
   SET ( ASSIMP_BUILD_DRACO OFF CACHE BOOL "Disabled: Draco requires newer cmake" FORCE )
 ELSE()
   OPTION ( ASSIMP_BUILD_DRACO "If the Draco libraries are to be built. Primarily for glTF" OFF )
   IF ( ASSIMP_BUILD_DRACO )
     # Primarily for glTF v2
     # Enable Draco glTF feature set
-    set(DRACO_GLTF_BITSTREAM ON CACHE BOOL "" FORCE)
+    SET(DRACO_GLTF_BITSTREAM ON CACHE BOOL "" FORCE)
     # Disable unnecessary or omitted components
-    set(DRACO_JS_GLUE OFF CACHE BOOL "" FORCE)
-    set(DRACO_WASM OFF CACHE BOOL "" FORCE)
-    set(DRACO_MAYA_PLUGIN OFF CACHE BOOL "" FORCE)
-    set(DRACO_UNITY_PLUGIN OFF CACHE BOOL "" FORCE)
-    set(DRACO_TESTS OFF CACHE BOOL "" FORCE)
+    SET(DRACO_JS_GLUE OFF CACHE BOOL "" FORCE)
+    SET(DRACO_WASM OFF CACHE BOOL "" FORCE)
+    SET(DRACO_MAYA_PLUGIN OFF CACHE BOOL "" FORCE)
+    SET(DRACO_UNITY_PLUGIN OFF CACHE BOOL "" FORCE)
+    SET(DRACO_TESTS OFF CACHE BOOL "" FORCE)
 
     IF(ASSIMP_HUNTER_ENABLED)
       hunter_add_package(draco)
       find_package(draco CONFIG REQUIRED)
-      set(draco_LIBRARIES draco::draco)
+      SET(draco_LIBRARIES draco::draco)
     ELSE()
       # Draco 1.4.1 has many warnings and will not build with /WX or -Werror
       # See https://github.com/google/draco/issues/672
       # and https://github.com/google/draco/issues/673
       IF(MSVC)
-        set(DRACO_CXX_FLAGS "/W0")
+        SET(DRACO_CXX_FLAGS "/W0")
       ELSE()
-        list(APPEND DRACO_CXX_FLAGS
+        LIST(APPEND DRACO_CXX_FLAGS
           "-Wno-bool-compare"
           "-Wno-comment"
           "-Wno-maybe-uninitialized"
@@ -721,30 +722,30 @@ ELSE()
           "-Wno-unused-local-typedefs"
         )
 
-        if(NOT ASSIMP_BUILD_DRACO_STATIC)
+        IF(NOT ASSIMP_BUILD_DRACO_STATIC)
           # Draco 1.4.1 does not explicitly export any symbols under GCC/clang
-          list(APPEND DRACO_CXX_FLAGS
+          LIST(APPEND DRACO_CXX_FLAGS
             "-fvisibility=default"
           )
-        endif()
+        ENDIF()
       ENDIF()
 
       # Don't build or install all of Draco by default
       ADD_SUBDIRECTORY( "contrib/draco" EXCLUDE_FROM_ALL )
 
-      if(ASSIMP_BUILD_DRACO_STATIC)
+      IF(ASSIMP_BUILD_DRACO_STATIC)
         set_property(DIRECTORY "contrib/draco" PROPERTY BUILD_SHARED_LIBS OFF)
-      endif()
+      ENDIF()
 
-      if(MSVC OR WIN32)
-        set(draco_LIBRARIES "draco")
-      else()
-        if(ASSIMP_BUILD_DRACO_STATIC)
-          set(draco_LIBRARIES "draco_static")
-        else()
-          set(draco_LIBRARIES "draco_shared")
-        endif()
-      endif()
+      IF(MSVC OR WIN32)
+        SET(draco_LIBRARIES "draco")
+      ELSE()
+        IF(ASSIMP_BUILD_DRACO_STATIC)
+          SET(draco_LIBRARIES "draco_static")
+        ELSE()
+          SET(draco_LIBRARIES "draco_shared")
+        ENDIF()
+      ENDIF()
 
       # Don't build the draco command-line tools by default
       set_target_properties(draco_encoder draco_decoder PROPERTIES
@@ -762,10 +763,10 @@ ELSE()
       TARGET_USE_COMMON_OUTPUT_DIRECTORY(draco_encoder)
       TARGET_USE_COMMON_OUTPUT_DIRECTORY(draco_decoder)
 
-      set(draco_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/contrib/draco/src")
+      SET(draco_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/contrib/draco/src")
 
       # This is probably wrong
-      if (ASSIMP_INSTALL)
+      IF (ASSIMP_INSTALL)
         INSTALL( TARGETS ${draco_LIBRARIES}
           EXPORT "${TARGETS_EXPORT_NAME}"
           LIBRARY DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
@@ -775,7 +776,7 @@ ELSE()
           COMPONENT ${LIBASSIMP_COMPONENT}
           INCLUDES DESTINATION include
         )
-      endif()
+      ENDIF()
     ENDIF()
   ENDIF()
 ENDIF()

--- a/code/AssetLib/CSM/CSMLoader.cpp
+++ b/code/AssetLib/CSM/CSMLoader.cpp
@@ -176,9 +176,17 @@ void CSMImporter::InternReadFile( const std::string& pFile,
                 // If we know how many frames we'll read, we can preallocate some storage
                 unsigned int alloc = 100;
                 if (last != 0x00ffffff) {
+                    // re-init if the file has last frame data
                     alloc = last-first;
                     alloc += alloc>>2u; // + 25%
                     for (unsigned int i = 0; i < anim->mNumChannels; ++i) {
+                        if (anim->mChannels[i]->mPositionKeys != nullptr) delete[] anim->mChannels[i]->mPositionKeys;
+                        anim->mChannels[i]->mPositionKeys = new aiVectorKey[alloc];
+                    }
+                } else {
+                    // default init
+                    for (unsigned int i = 0; i < anim->mNumChannels; ++i) {
+                        if (anim->mChannels[i]->mPositionKeys != nullptr) continue;
                         anim->mChannels[i]->mPositionKeys = new aiVectorKey[alloc];
                     }
                 }
@@ -202,7 +210,7 @@ void CSMImporter::InternReadFile( const std::string& pFile,
                         if (s->mNumPositionKeys == alloc)   {
                             // need to reallocate?
                             aiVectorKey* old = s->mPositionKeys;
-                            s->mPositionKeys = new aiVectorKey[s->mNumPositionKeys = alloc*2];
+                            s->mPositionKeys = new aiVectorKey[alloc*2];
                             ::memcpy(s->mPositionKeys,old,sizeof(aiVectorKey)*alloc);
                             delete[] old;
                         }

--- a/code/AssetLib/CSM/CSMLoader.cpp
+++ b/code/AssetLib/CSM/CSMLoader.cpp
@@ -271,7 +271,13 @@ void CSMImporter::InternReadFile( const std::string& pFile,
         nd->mName   = anim->mChannels[i]->mNodeName;
         nd->mParent = pScene->mRootNode;
 
-        aiMatrix4x4::Translation(na->mPositionKeys[0].mValue, nd->mTransformation);
+        if (na->mPositionKeys != nullptr && na->mNumPositionKeys > 0) {
+            aiMatrix4x4::Translation(na->mPositionKeys[0].mValue, nd->mTransformation);
+        } else {
+            // Use identity matrix if no valid position data is available
+            nd->mTransformation = aiMatrix4x4();
+            DefaultLogger::get()->warn("CSM: No position keys available for node - using identity transformation");
+        }
     }
 
     // Store the one and only animation in the scene

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -886,7 +886,7 @@ void ColladaParser::ReadController(XmlNode &node, Collada::Controller &controlle
             XmlParser::getValueAsString(currentNode, v);
             const char *content = v.c_str();
             const char *end = content + v.size();
-            for (float & a : controller.mBindShapeMatrix) {
+            for (auto & a : controller.mBindShapeMatrix) {
                 SkipSpacesAndLineEnd(&content, end);
                 // read a number
                 content = fast_atoreal_move<ai_real>(content, a);

--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -1329,14 +1329,13 @@ void FBXExporter::WriteObjects () {
         } else {
           mat.AddChild("MappingInformationType", "ByPolygon");
           mat.AddChild("ReferenceInformationType", "IndexToDirect");
-          std::vector<int32_t> mat_indices(polygon_data.size());
-          uint32_t curr_offset = 0;
-          for (uint32_t mi = 0; mi < node->mNumMeshes; mi++) {
-            uint32_t num_faces = mScene->mMeshes[node->mMeshes[mi]]->mNumFaces;
-            for (uint32_t fi = 0; fi < num_faces; fi++) {
-              mat_indices[curr_offset + fi] = mi;
+          std::vector<int32_t> mat_indices;
+          for (uint32_t n_mi = 0; n_mi < node->mNumMeshes; n_mi++) {
+            const auto mi = node->mMeshes[n_mi];
+            const auto *const m = mScene->mMeshes[mi];
+            for (size_t fi = 0; fi < m->mNumFaces; fi++) {
+              mat_indices.push_back(n_mi);
             }
-            curr_offset += num_faces;
           }
           mat.AddChild("Materials", mat_indices);
         }

--- a/code/AssetLib/MD5/MD5Parser.cpp
+++ b/code/AssetLib/MD5/MD5Parser.cpp
@@ -277,6 +277,8 @@ inline bool AI_MD5_PARSE_STRING(const char **sz, const char *bufferEnd, aiString
         }
     }
     out.length = (ai_uint32)(szEnd - szStart);
+    if (out.length >= AI_MAXLEN)
+        out.length = AI_MAXLEN - 1;
     ::memcpy(out.data, szStart, out.length);
     out.data[out.length] = '\0';
 
@@ -299,6 +301,8 @@ inline void AI_MD5_PARSE_STRING_IN_QUOTATION(const char **sz, const char *buffer
             const char *szEnd = *sz;
             ++*sz;
             out.length = (ai_uint32)(szEnd - szStart);
+            if (out.length >= AI_MAXLEN)
+                out.length = AI_MAXLEN - 1;
             ::memcpy(out.data, szStart, out.length);
         }
     }

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -515,7 +515,7 @@ void glTFImporter::ImportLights(Asset &r) {
         CopyValue(l.color, ail->mColorSpecular);
 
         ail->mAngleOuterCone = l.falloffAngle;
-        ail->mAngleInnerCone = l.falloffExponent; // TODO fix this, it does not look right at all
+        ail->mAngleInnerCone = l.falloffAngle * (1.0f - 1.0f / (1.0f + l.falloffExponent)); 
 
         ail->mAttenuationConstant = l.constantAttenuation;
         ail->mAttenuationLinear = l.linearAttenuation;

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1122,6 +1122,7 @@ IF(ASSIMP_HUNTER_ENABLED)
 ELSEIF(NOT TARGET pugixml::pugixml)
   SET( Pugixml_SRCS
     ../contrib/pugixml/src/pugiconfig.hpp
+    ../contrib/pugixml/src/pugixml.cpp
     ../contrib/pugixml/src/pugixml.hpp
   )
   INCLUDE_DIRECTORIES("../contrib/pugixml/src")
@@ -1465,7 +1466,7 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
         -Wno-undefined-func-template
         -Wno-declaration-after-statement
         -Wno-deprecated-declarations
-	-Wno-deprecated-non-prototype
+	      -Wno-deprecated-non-prototype
       )
     ELSE()
       TARGET_COMPILE_OPTIONS(assimp PRIVATE /W4 /WX)

--- a/contrib/pugixml/CMakeLists.txt
+++ b/contrib/pugixml/CMakeLists.txt
@@ -1,87 +1,297 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.30)
 
-project(pugixml)
-
-option(BUILD_SHARED_LIBS "Build shared instead of static library" OFF)
-option(BUILD_TESTS "Build tests" OFF)
-option(BUILD_PKGCONFIG "Build in PKGCONFIG mode" OFF)
-
-set(BUILD_DEFINES "" CACHE STRING "Build defines")
-
-if(MSVC)
-	option(STATIC_CRT "Use static CRT libraries" OFF)
-
-	# Rewrite command line flags to use /MT if necessary
-	if(STATIC_CRT)
-		foreach(flag_var
-				CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-				CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-			if(${flag_var} MATCHES "/MD")
-				string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-			endif(${flag_var} MATCHES "/MD")
-		endforeach(flag_var)
-	endif()
+# Policy configuration; this *MUST* be specified before project is defined
+if(POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW) # Enables use of MSVC_RUNTIME_LIBRARY
 endif()
 
-# Pre-defines standard install locations on *nix systems.
+project(pugixml VERSION 1.15 LANGUAGES CXX)
+
+include(CMakePackageConfigHelpers)
+include(CMakeDependentOption)
 include(GNUInstallDirs)
-mark_as_advanced(CLEAR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR)
 
-set(HEADERS src/pugixml.hpp src/pugiconfig.hpp)
-set(SOURCES src/pugixml.cpp)
+cmake_dependent_option(PUGIXML_USE_VERSIONED_LIBDIR
+  "Use a private subdirectory to install the headers and libraries" OFF
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
-if(DEFINED BUILD_DEFINES)
-	foreach(DEFINE ${BUILD_DEFINES})
-		add_definitions("-D" ${DEFINE})
-	endforeach()
-endif()
-#message(pugixml"   "${BUILD_SHARED_LIBS})
-#if(BUILD_SHARED_LIBS)
-#	add_library(pugixml SHARED ${HEADERS} ${SOURCES})
-#else()
-	add_library(pugixml STATIC ${HEADERS} ${SOURCES})
-#endif()
+cmake_dependent_option(PUGIXML_USE_POSTFIX
+  "Use separate postfix for each configuration to make sure you can install multiple build outputs" OFF
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
-# Export symbols for shared library builds
-if(BUILD_SHARED_LIBS AND MSVC)
-	target_compile_definitions(pugixml PRIVATE "PUGIXML_API=__declspec(dllexport)")
-endif()
+cmake_dependent_option(PUGIXML_STATIC_CRT
+  "Use static MSVC RT libraries" OFF
+  "MSVC" OFF)
 
-# Enable C++11 long long for compilers that are capable of it
-if(NOT ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} STRLESS 3.1 AND ";${CMAKE_CXX_COMPILE_FEATURES};" MATCHES ";cxx_long_long_type;")
-	target_compile_features(pugixml PUBLIC cxx_long_long_type)
-endif()
+cmake_dependent_option(PUGIXML_BUILD_TESTS
+  "Build pugixml tests" OFF
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
 
-set_target_properties(pugixml PROPERTIES VERSION 1.9 SOVERSION 1)
-get_target_property(PUGIXML_VERSION_STRING pugixml VERSION)
+# Custom build defines
+set(PUGIXML_BUILD_DEFINES CACHE STRING "Build defines for custom options")
+separate_arguments(PUGIXML_BUILD_DEFINES)
 
-if(BUILD_PKGCONFIG)
-	# Install library into its own directory under LIBDIR
-	set(INSTALL_SUFFIX /pugixml-${PUGIXML_VERSION_STRING})
-endif()
+# Technically not needed for this file. This is builtin CMAKE global variable.
+option(BUILD_SHARED_LIBS "Build shared instead of static library")
 
-target_include_directories(pugixml PUBLIC
-	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src>
-	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX}>)
+# Expose option to build PUGIXML as static as well when the global BUILD_SHARED_LIBS variable is set
+cmake_dependent_option(PUGIXML_BUILD_SHARED_AND_STATIC_LIBS
+  "Build both shared and static libraries" OFF
+  "BUILD_SHARED_LIBS" OFF)
 
-install(TARGETS pugixml EXPORT pugixml-config
-	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}
-	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${INSTALL_SUFFIX})
-install(EXPORT pugixml-config DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml)
+# Expose options from the pugiconfig.hpp
+option(PUGIXML_WCHAR_MODE "Enable wchar_t mode" OFF)
+option(PUGIXML_COMPACT "Enable compact mode" OFF)
+option(PUGIXML_INSTALL "Enable installation rules" ON)
 
-if(BUILD_PKGCONFIG)
-	configure_file(scripts/pugixml.pc.in ${PROJECT_BINARY_DIR}/pugixml.pc @ONLY)
-	install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+# Advanced options from pugiconfig.hpp
+option(PUGIXML_NO_XPATH "Disable XPath" OFF)
+option(PUGIXML_NO_STL "Disable STL" OFF)
+option(PUGIXML_NO_EXCEPTIONS "Disable Exceptions" OFF)
+mark_as_advanced(PUGIXML_NO_XPATH PUGIXML_NO_STL PUGIXML_NO_EXCEPTIONS)
+
+if (APPLE)
+  option(PUGIXML_BUILD_APPLE_FRAMEWORK "Build as Apple Frameworks" OFF)
 endif()
 
-if(BUILD_TESTS)
-	file(GLOB TEST_SOURCES tests/*.cpp)
-	file(GLOB FUZZ_SOURCES tests/fuzz_*.cpp)
-	list(REMOVE_ITEM TEST_SOURCES ${FUZZ_SOURCES})
+set(PUGIXML_PUBLIC_DEFINITIONS
+  $<$<BOOL:${PUGIXML_WCHAR_MODE}>:PUGIXML_WCHAR_MODE>
+  $<$<BOOL:${PUGIXML_COMPACT}>:PUGIXML_COMPACT>
+  $<$<BOOL:${PUGIXML_NO_XPATH}>:PUGIXML_NO_XPATH>
+  $<$<BOOL:${PUGIXML_NO_STL}>:PUGIXML_NO_STL>
+  $<$<BOOL:${PUGIXML_NO_EXCEPTIONS}>:PUGIXML_NO_EXCEPTIONS>
+)
 
-	add_executable(check ${TEST_SOURCES})
-	target_link_libraries(check pugixml)
-	add_custom_command(TARGET check POST_BUILD COMMAND check WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+# This is used to backport a CMake 3.15 feature, but is also forwards compatible
+if (NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY
+    MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<NOT:$<BOOL:${PUGIXML_STATIC_CRT}>>:DLL>)
+endif()
+
+# Set the default C++ standard to C++17 if not set; CMake will automatically downgrade this if the compiler does not support it
+# When CMAKE_CXX_STANDARD_REQUIRED is set, we fall back to C++11 to avoid breaking older compilers
+if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED AND NOT DEFINED CMAKE_CXX_STANDARD AND NOT CMAKE_VERSION VERSION_LESS 3.8)
+
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+elseif (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+
+if (PUGIXML_USE_POSTFIX)
+  set(CMAKE_RELWITHDEBINFO_POSTFIX _r)
+  set(CMAKE_MINSIZEREL_POSTFIX _m)
+  set(CMAKE_DEBUG_POSTFIX _d)
+endif()
+
+if (CMAKE_VERSION VERSION_LESS 3.15)
+  set(msvc-rt $<TARGET_PROPERTY:MSVC_RUNTIME_LIBRARY>)
+
+  set(msvc-rt-mtd-shared $<STREQUAL:${msvc-rt},MultiThreadedDebugDLL>)
+  set(msvc-rt-mtd-static $<STREQUAL:${msvc-rt},MultiThreadedDebug>)
+  set(msvc-rt-mt-shared $<STREQUAL:${msvc-rt},MultiThreadedDLL>)
+  set(msvc-rt-mt-static $<STREQUAL:${msvc-rt},MultiThreaded>)
+  unset(msvc-rt)
+
+  set(msvc-rt-mtd-shared $<${msvc-rt-mtd-shared}:-MDd>)
+  set(msvc-rt-mtd-static $<${msvc-rt-mtd-static}:-MTd>)
+  set(msvc-rt-mt-shared $<${msvc-rt-mt-shared}:-MD>)
+  set(msvc-rt-mt-static $<${msvc-rt-mt-static}:-MT>)
+endif()
+
+set(versioned-dir $<$<BOOL:${PUGIXML_USE_VERSIONED_LIBDIR}>:/pugixml-${PROJECT_VERSION}>)
+
+set(libs)
+
+if (BUILD_SHARED_LIBS)
+  add_library(pugixml-shared SHARED
+    ${PROJECT_SOURCE_DIR}/scripts/pugixml_dll.rc
+    ${PROJECT_SOURCE_DIR}/src/pugixml.cpp)
+  add_library(pugixml::shared ALIAS pugixml-shared)
+  list(APPEND libs pugixml-shared)
+  string(CONCAT pugixml.msvc $<OR:
+    $<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},MSVC>,
+    $<CXX_COMPILER_ID:MSVC>
+  >)
+
+  set_property(TARGET pugixml-shared PROPERTY EXPORT_NAME shared)
+  target_include_directories(pugixml-shared
+    PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+  target_compile_definitions(pugixml-shared
+    PUBLIC
+      ${PUGIXML_BUILD_DEFINES}
+      ${PUGIXML_PUBLIC_DEFINITIONS}
+    PRIVATE
+      PUGIXML_API=$<IF:${pugixml.msvc},__declspec\(dllexport\),__attribute__\(\(visibility\("default"\)\)\)>
+    )
+  target_compile_options(pugixml-shared
+    PRIVATE
+      ${msvc-rt-mtd-shared}
+      ${msvc-rt-mtd-static}
+      ${msvc-rt-mt-shared}
+      ${msvc-rt-mt-static})
+endif()
+
+if (NOT BUILD_SHARED_LIBS OR PUGIXML_BUILD_SHARED_AND_STATIC_LIBS)
+  add_library(pugixml-static STATIC
+    ${PROJECT_SOURCE_DIR}/src/pugixml.cpp)
+  add_library(pugixml::static ALIAS pugixml-static)
+  list(APPEND libs pugixml-static)
+
+  set_property(TARGET pugixml-static PROPERTY EXPORT_NAME static)
+  target_include_directories(pugixml-static
+    PUBLIC
+      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+  target_compile_definitions(pugixml-static
+    PUBLIC
+      ${PUGIXML_BUILD_DEFINES}
+      ${PUGIXML_PUBLIC_DEFINITIONS})
+  target_compile_options(pugixml-static
+    PRIVATE
+      ${msvc-rt-mtd-shared}
+      ${msvc-rt-mtd-static}
+      ${msvc-rt-mt-shared}
+      ${msvc-rt-mt-static})
+endif()
+
+if (BUILD_SHARED_LIBS)
+  set(pugixml-alias pugixml-shared)
+else()
+  set(pugixml-alias pugixml-static)
+endif()
+add_library(pugixml INTERFACE)
+target_link_libraries(pugixml INTERFACE ${pugixml-alias})
+add_library(pugixml::pugixml ALIAS pugixml)
+
+set_target_properties(${libs}
+  PROPERTIES
+    MSVC_RUNTIME_LIBRARY ${CMAKE_MSVC_RUNTIME_LIBRARY}
+    EXCLUDE_FROM_ALL ON
+    POSITION_INDEPENDENT_CODE ON
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    VERSION ${PROJECT_VERSION}
+    OUTPUT_NAME pugixml)
+
+set_target_properties(${libs}
+  PROPERTIES
+    EXCLUDE_FROM_ALL OFF)
+set(install-targets pugixml ${libs})
+
+if (PUGIXML_BUILD_APPLE_FRAMEWORK)
+  set_target_properties(${libs} PROPERTIES
+    FRAMEWORK TRUE
+    FRAMEWORK_VERSION ${PROJECT_VERSION}
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.zeux.pugixml
+    MACOSX_FRAMEWORK_IDENTIFIER com.zeux.pugixml
+    MACOSX_FRAMEWORK_BUNDLE_VERSION ${PROJECT_VERSION}
+    MACOSX_FRAMEWORK_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR})
+endif()
+
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/scripts/pugixml-config.cmake.in"
+  "${PROJECT_BINARY_DIR}/pugixml-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  NO_SET_AND_CHECK_MACRO)
+
+write_basic_package_version_file(
+  "${PROJECT_BINARY_DIR}/pugixml-config-version.cmake"
+  COMPATIBILITY SameMajorVersion)
+
+if (PUGIXML_USE_POSTFIX)
+  if(CMAKE_BUILD_TYPE MATCHES RelWithDebInfo)
+    set(LIB_POSTFIX ${CMAKE_RELWITHDEBINFO_POSTFIX})
+  elseif(CMAKE_BUILD_TYPE MATCHES MinSizeRel)
+    set(LIB_POSTFIX ${CMAKE_MINSIZEREL_POSTFIX})
+  elseif(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(LIB_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+  endif()
+endif()
+
+# Handle both relative and absolute paths (e.g. NixOS) for a relocatable package
+if(IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+  set(PUGIXML_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+else()
+  set(PUGIXML_PC_INCLUDEDIR "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+endif()
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+  set(PUGIXML_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+  set(PUGIXML_PC_LIBDIR "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+endif()
+configure_file(scripts/pugixml.pc.in pugixml.pc @ONLY)
+
+export(TARGETS ${install-targets}
+  NAMESPACE pugixml::
+  FILE pugixml-targets.cmake)
+
+if(PUGIXML_INSTALL)
+  if (NOT DEFINED PUGIXML_RUNTIME_COMPONENT)
+    set(PUGIXML_RUNTIME_COMPONENT Runtime)
+  endif()
+
+  if (NOT DEFINED PUGIXML_LIBRARY_COMPONENT)
+    set(PUGIXML_LIBRARY_COMPONENT Library)
+  endif()
+
+  if (NOT DEFINED PUGIXML_DEVELOPMENT_COMPONENT)
+    set(PUGIXML_DEVELOPMENT_COMPONENT Development)
+  endif()
+
+  set(namelink-component)
+  if (NOT CMAKE_VERSION VERSION_LESS 3.12)
+    set(namelink-component NAMELINK_COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+  endif()
+  install(TARGETS ${install-targets}
+    EXPORT pugixml-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT ${PUGIXML_RUNTIME_COMPONENT}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${PUGIXML_LIBRARY_COMPONENT} ${namelink-component}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir}
+    FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime OPTIONAL)
+
+  install(EXPORT pugixml-targets
+    NAMESPACE pugixml::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+
+  install(FILES
+    "${PROJECT_BINARY_DIR}/pugixml-config-version.cmake"
+    "${PROJECT_BINARY_DIR}/pugixml-config.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pugixml COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+
+  install(FILES ${PROJECT_BINARY_DIR}/pugixml.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+
+  install(
+    FILES
+      "${PROJECT_SOURCE_DIR}/src/pugiconfig.hpp"
+      "${PROJECT_SOURCE_DIR}/src/pugixml.hpp"
+    DESTINATION
+      ${CMAKE_INSTALL_INCLUDEDIR}${versioned-dir} COMPONENT ${PUGIXML_DEVELOPMENT_COMPONENT})
+endif()
+
+if (PUGIXML_BUILD_TESTS)
+  include(CTest)
+  set(fuzz-pattern "tests/fuzz_*.cpp")
+  set(test-pattern "tests/*.cpp")
+  if (CMAKE_VERSION VERSION_GREATER 3.11)
+    list(INSERT fuzz-pattern 0 CONFIGURE_DEPENDS)
+    list(INSERT test-pattern 0 CONFIGURE_DEPENDS)
+  endif()
+  file(GLOB test-sources ${test-pattern})
+  file(GLOB fuzz-sources ${fuzz-pattern})
+  list(REMOVE_ITEM test-sources ${fuzz-sources})
+
+  add_custom_target(check
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
+
+  add_executable(pugixml-check ${test-sources})
+  add_test(NAME pugixml::test
+    COMMAND pugixml-check
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  add_dependencies(check pugixml-check)
+  target_link_libraries(pugixml-check
+    PRIVATE
+      pugixml::pugixml)
 endif()

--- a/contrib/pugixml/LICENSE.md
+++ b/contrib/pugixml/LICENSE.md
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright (c) 2006-2025 Arseny Kapoulkine
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/contrib/pugixml/readme.txt
+++ b/contrib/pugixml/readme.txt
@@ -1,6 +1,6 @@
-pugixml 1.13 - an XML processing library
+pugixml 1.15 - an XML processing library
 
-Copyright (c) 2006-2024, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
+Copyright (C) 2006-2025, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
 Report bugs and download new versions at https://pugixml.org/
 
 This is the distribution of pugixml, which is a C++ XML processing library,
@@ -26,7 +26,7 @@ The distribution contains the following folders:
 
 This library is distributed under the MIT License:
 
-Copyright (c) 2006-2024 Arseny Kapoulkine
+Copyright (c) 2006-2025 Arseny Kapoulkine
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/contrib/pugixml/src/pugiconfig.hpp
+++ b/contrib/pugixml/src/pugiconfig.hpp
@@ -1,7 +1,7 @@
 /**
- * pugixml parser - version 1.13
+ * pugixml parser - version 1.15
  * --------------------------------------------------------
- * Copyright (c) 2006-2024, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
+ * Copyright (C) 2006-2025, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
  * Report bugs and download new versions at https://pugixml.org/
  *
  * This library is distributed under the MIT License. See notice at the end
@@ -30,9 +30,14 @@
 // #define PUGIXML_NO_EXCEPTIONS
 
 // Set this to control attributes for public classes/functions, i.e.:
-// #define PUGIXML_API __declspec(dllexport) // to export all public symbols from DLL
-// #define PUGIXML_CLASS __declspec(dllimport) // to import all classes from DLL
-// #define PUGIXML_FUNCTION __fastcall // to set calling conventions to all public functions to fastcall
+#ifdef _WIN32
+#   define PUGIXML_API __declspec(dllexport) // to export all public symbols from DLL
+#else
+#  define PUGIXML_API __attribute__((visibility("default")))
+#endif // _WIN32
+#
+//define PUGIXML_CLASS __declspec(dllimport) // to import all classes from DLL
+//#define PUGIXML_FUNCTION __fastcall // to set calling conventions to all public functions to fastcall
 // In absence of PUGIXML_CLASS/PUGIXML_FUNCTION definitions PUGIXML_API is used instead
 
 // Tune these constants to adjust memory-related behavior
@@ -44,15 +49,18 @@
 // #define PUGIXML_XPATH_DEPTH_LIMIT 1024
 
 // Uncomment this to switch to header-only version
-#define PUGIXML_HEADER_ONLY
+// #define PUGIXML_HEADER_ONLY
 
-// Uncomment this to enable long long support
+// Uncomment this to enable long long support (usually enabled automatically)
 // #define PUGIXML_HAS_LONG_LONG
+
+// Uncomment this to enable support for std::string_view (usually enabled automatically)
+// #define PUGIXML_HAS_STRING_VIEW
 
 #endif
 
 /**
- * Copyright (c) 2006-2024 Arseny Kapoulkine
+ * Copyright (c) 2006-2025 Arseny Kapoulkine
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/contrib/pugixml/src/pugixml.cpp
+++ b/contrib/pugixml/src/pugixml.cpp
@@ -1,7 +1,7 @@
 /**
- * pugixml parser - version 1.13
+ * pugixml parser - version 1.15
  * --------------------------------------------------------
- * Copyright (c) 2006-2024, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
+ * Copyright (C) 2006-2025, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
  * Report bugs and download new versions at https://pugixml.org/
  *
  * This library is distributed under the MIT License. See notice at the end
@@ -40,12 +40,22 @@
 // For placement new
 #include <new>
 
+// For load_file
+#if defined(__linux__) || defined(__APPLE__)
+#include <sys/stat.h>
+#endif
+
 #ifdef _MSC_VER
 #	pragma warning(push)
 #	pragma warning(disable: 4127) // conditional expression is constant
 #	pragma warning(disable: 4324) // structure was padded due to __declspec(align())
 #	pragma warning(disable: 4702) // unreachable code
 #	pragma warning(disable: 4996) // this function or variable may be unsafe
+#endif
+
+#if defined(__clang__)
+#	pragma clang diagnostic push
+#	pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant" // NULL as null pointer constant
 #endif
 
 #if defined(_MSC_VER) && defined(__c2__)
@@ -82,39 +92,39 @@
 
 // Inlining controls
 #if defined(_MSC_VER) && _MSC_VER >= 1300
-#	define PUGI__NO_INLINE __declspec(noinline)
+#	define PUGI_IMPL_NO_INLINE __declspec(noinline)
 #elif defined(__GNUC__)
-#	define PUGI__NO_INLINE __attribute__((noinline))
+#	define PUGI_IMPL_NO_INLINE __attribute__((noinline))
 #else
-#	define PUGI__NO_INLINE
+#	define PUGI_IMPL_NO_INLINE
 #endif
 
 // Branch weight controls
 #if defined(__GNUC__) && !defined(__c2__)
-#	define PUGI__UNLIKELY(cond) __builtin_expect(cond, 0)
+#	define PUGI_IMPL_UNLIKELY(cond) __builtin_expect(cond, 0)
 #else
-#	define PUGI__UNLIKELY(cond) (cond)
+#	define PUGI_IMPL_UNLIKELY(cond) (cond)
 #endif
 
 // Simple static assertion
-#define PUGI__STATIC_ASSERT(cond) { static const char condition_failed[(cond) ? 1 : -1] = {0}; (void)condition_failed[0]; }
+#define PUGI_IMPL_STATIC_ASSERT(cond) { static const char condition_failed[(cond) ? 1 : -1] = {0}; (void)condition_failed[0]; }
 
 // Digital Mars C++ bug workaround for passing char loaded from memory via stack
 #ifdef __DMC__
-#	define PUGI__DMC_VOLATILE volatile
+#	define PUGI_IMPL_DMC_VOLATILE volatile
 #else
-#	define PUGI__DMC_VOLATILE
+#	define PUGI_IMPL_DMC_VOLATILE
 #endif
 
 // Integer sanitizer workaround; we only apply this for clang since gcc8 has no_sanitize but not unsigned-integer-overflow and produces "attribute directive ignored" warnings
 #if defined(__clang__) && defined(__has_attribute)
 #	if __has_attribute(no_sanitize)
-#		define PUGI__UNSIGNED_OVERFLOW __attribute__((no_sanitize("unsigned-integer-overflow")))
+#		define PUGI_IMPL_UNSIGNED_OVERFLOW __attribute__((no_sanitize("unsigned-integer-overflow")))
 #	else
-#		define PUGI__UNSIGNED_OVERFLOW
+#		define PUGI_IMPL_UNSIGNED_OVERFLOW
 #	endif
 #else
-#	define PUGI__UNSIGNED_OVERFLOW
+#	define PUGI_IMPL_UNSIGNED_OVERFLOW
 #endif
 
 // Borland C++ bug workaround for not defining ::memcpy depending on header include order (can't always use std::memcpy because some compilers don't have it at all)
@@ -122,6 +132,12 @@
 using std::memcpy;
 using std::memmove;
 using std::memset;
+#endif
+
+// Old versions of GCC do not define ::malloc and ::free depending on header include order
+#if defined(__GNUC__) && (__GNUC__ < 3 || (__GNUC__ == 3 && __GNUC_MINOR__ < 4))
+using std::malloc;
+using std::free;
 #endif
 
 // Some MinGW/GCC versions have headers that erroneously omit LLONG_MIN/LLONG_MAX/ULLONG_MAX definitions from limits.h in some configurations
@@ -133,36 +149,38 @@ using std::memset;
 
 // In some environments MSVC is a compiler but the CRT lacks certain MSVC-specific features
 #if defined(_MSC_VER) && !defined(__S3E__) && !defined(_WIN32_WCE)
-#	define PUGI__MSVC_CRT_VERSION _MSC_VER
+#	define PUGI_IMPL_MSVC_CRT_VERSION _MSC_VER
 #elif defined(_WIN32_WCE)
-#	define PUGI__MSVC_CRT_VERSION 1310 // MSVC7.1
+#	define PUGI_IMPL_MSVC_CRT_VERSION 1310 // MSVC7.1
 #endif
 
 // Not all platforms have snprintf; we define a wrapper that uses snprintf if possible. This only works with buffers with a known size.
 #if __cplusplus >= 201103
-#	define PUGI__SNPRINTF(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
-#elif defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
-#	define PUGI__SNPRINTF(buf, ...) _snprintf_s(buf, _countof(buf), _TRUNCATE, __VA_ARGS__)
+#	define PUGI_IMPL_SNPRINTF(buf, ...) snprintf(buf, sizeof(buf), __VA_ARGS__)
+#elif defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
+#	define PUGI_IMPL_SNPRINTF(buf, ...) _snprintf_s(buf, _countof(buf), _TRUNCATE, __VA_ARGS__)
+#elif defined(__APPLE__) && __clang_major__ >= 14 // Xcode 14 marks sprintf as deprecated while still using C++98 by default
+#	define PUGI_IMPL_SNPRINTF(buf, fmt, arg1, arg2) snprintf(buf, sizeof(buf), fmt, arg1, arg2)
 #else
-#	define PUGI__SNPRINTF sprintf
+#	define PUGI_IMPL_SNPRINTF sprintf
 #endif
 
 // We put implementation details into an anonymous namespace in source mode, but have to keep it in non-anonymous namespace in header-only mode to prevent binary bloat.
 #ifdef PUGIXML_HEADER_ONLY
-#	define PUGI__NS_BEGIN namespace pugi { namespace impl {
-#	define PUGI__NS_END } }
-#	define PUGI__FN inline
-#	define PUGI__FN_NO_INLINE inline
+#	define PUGI_IMPL_NS_BEGIN namespace pugi { namespace impl {
+#	define PUGI_IMPL_NS_END } }
+#	define PUGI_IMPL_FN inline
+#	define PUGI_IMPL_FN_NO_INLINE inline
 #else
 #	if defined(_MSC_VER) && _MSC_VER < 1300 // MSVC6 seems to have an amusing bug with anonymous namespaces inside namespaces
-#		define PUGI__NS_BEGIN namespace pugi { namespace impl {
-#		define PUGI__NS_END } }
+#		define PUGI_IMPL_NS_BEGIN namespace pugi { namespace impl {
+#		define PUGI_IMPL_NS_END } }
 #	else
-#		define PUGI__NS_BEGIN namespace pugi { namespace impl { namespace {
-#		define PUGI__NS_END } } }
+#		define PUGI_IMPL_NS_BEGIN namespace pugi { namespace impl { namespace {
+#		define PUGI_IMPL_NS_END } } }
 #	endif
-#	define PUGI__FN
-#	define PUGI__FN_NO_INLINE PUGI__NO_INLINE
+#	define PUGI_IMPL_FN
+#	define PUGI_IMPL_FN_NO_INLINE PUGI_IMPL_NO_INLINE
 #endif
 
 // uintptr_t
@@ -182,13 +200,13 @@ namespace pugi
 #endif
 
 // Memory allocation
-PUGI__NS_BEGIN
-	PUGI__FN void* default_allocate(size_t size)
+PUGI_IMPL_NS_BEGIN
+	PUGI_IMPL_FN void* default_allocate(size_t size)
 	{
 		return malloc(size);
 	}
 
-	PUGI__FN void default_deallocate(void* ptr)
+	PUGI_IMPL_FN void default_deallocate(void* ptr)
 	{
 		free(ptr);
 	}
@@ -206,12 +224,12 @@ PUGI__NS_BEGIN
 	template <typename T> deallocation_function xml_memory_management_function_storage<T>::deallocate = default_deallocate;
 
 	typedef xml_memory_management_function_storage<int> xml_memory;
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // String utilities
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	// Get string length
-	PUGI__FN size_t strlength(const char_t* s)
+	PUGI_IMPL_FN size_t strlength(const char_t* s)
 	{
 		assert(s);
 
@@ -223,7 +241,7 @@ PUGI__NS_BEGIN
 	}
 
 	// Compare two strings
-	PUGI__FN bool strequal(const char_t* src, const char_t* dst)
+	PUGI_IMPL_FN bool strequal(const char_t* src, const char_t* dst)
 	{
 		assert(src && dst);
 
@@ -234,8 +252,26 @@ PUGI__NS_BEGIN
 	#endif
 	}
 
+#ifdef PUGIXML_HAS_STRING_VIEW
+	// Check if the null-terminated dst string is equal to the entire contents of srcview
+	PUGI_IMPL_FN bool stringview_equal(string_view_t srcview, const char_t* dst)
+	{
+		// std::basic_string_view::compare(const char*) has the right behavior, but it performs an
+		// extra traversal of dst to compute its length.
+		assert(dst);
+		const char_t* src = srcview.data();
+		size_t srclen = srcview.size();
+
+		while (srclen && *dst && *src == *dst)
+		{
+			--srclen; ++dst; ++src; 
+		}
+		return srclen == 0 && *dst == 0;
+	}
+#endif
+
 	// Compare lhs with [rhs_begin, rhs_end)
-	PUGI__FN bool strequalrange(const char_t* lhs, const char_t* rhs, size_t count)
+	PUGI_IMPL_FN bool strequalrange(const char_t* lhs, const char_t* rhs, size_t count)
 	{
 		for (size_t i = 0; i < count; ++i)
 			if (lhs[i] != rhs[i])
@@ -245,7 +281,7 @@ PUGI__NS_BEGIN
 	}
 
 	// Get length of wide string, even if CRT lacks wide character support
-	PUGI__FN size_t strlength_wide(const wchar_t* s)
+	PUGI_IMPL_FN size_t strlength_wide(const wchar_t* s)
 	{
 		assert(s);
 
@@ -257,10 +293,10 @@ PUGI__NS_BEGIN
 		return static_cast<size_t>(end - s);
 	#endif
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // auto_ptr-like object for exception recovery
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	template <typename T> struct auto_deleter
 	{
 		typedef void (*D)(T*);
@@ -280,18 +316,18 @@ PUGI__NS_BEGIN
 		T* release()
 		{
 			T* result = data;
-			data = 0;
+			data = nullptr;
 			return result;
 		}
 	};
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 #ifdef PUGIXML_COMPACT
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	class compact_hash_table
 	{
 	public:
-		compact_hash_table(): _items(0), _capacity(0), _count(0)
+		compact_hash_table(): _items(NULL), _capacity(0), _count(0)
 		{
 		}
 
@@ -300,7 +336,7 @@ PUGI__NS_BEGIN
 			if (_items)
 			{
 				xml_memory::deallocate(_items);
-				_items = 0;
+				_items = nullptr;
 				_capacity = 0;
 				_count = 0;
 			}
@@ -308,11 +344,11 @@ PUGI__NS_BEGIN
 
 		void* find(const void* key)
 		{
-			if (_capacity == 0) return 0;
+			if (_capacity == 0) return nullptr;
 
 			item_t* item = get_item(key);
 			assert(item);
-			assert(item->key == key || (item->key == 0 && item->value == 0));
+			assert(item->key == key || (item->key == nullptr && item->value == nullptr));
 
 			return item->value;
 		}
@@ -324,7 +360,7 @@ PUGI__NS_BEGIN
 			item_t* item = get_item(key);
 			assert(item);
 
-			if (item->key == 0)
+			if (item->key == nullptr)
 			{
 				_count++;
 				item->key = key;
@@ -367,7 +403,7 @@ PUGI__NS_BEGIN
 			{
 				item_t& probe_item = _items[bucket];
 
-				if (probe_item.key == key || probe_item.key == 0)
+				if (probe_item.key == key || probe_item.key == nullptr)
 					return &probe_item;
 
 				// hash collision, quadratic probing
@@ -375,10 +411,10 @@ PUGI__NS_BEGIN
 			}
 
 			assert(false && "Hash table is full"); // unreachable
-			return 0;
+			return nullptr;
 		}
 
-		static PUGI__UNSIGNED_OVERFLOW unsigned int hash(const void* key)
+		static PUGI_IMPL_UNSIGNED_OVERFLOW unsigned int hash(const void* key)
 		{
 			unsigned int h = static_cast<unsigned int>(reinterpret_cast<uintptr_t>(key) & 0xffffffff);
 
@@ -393,7 +429,7 @@ PUGI__NS_BEGIN
 		}
 	};
 
-	PUGI__FN_NO_INLINE bool compact_hash_table::rehash(size_t count)
+	PUGI_IMPL_FN_NO_INLINE bool compact_hash_table::rehash(size_t count)
 	{
 		size_t capacity = 32;
 		while (count >= capacity - capacity / 4)
@@ -423,10 +459,10 @@ PUGI__NS_BEGIN
 		return true;
 	}
 
-PUGI__NS_END
+PUGI_IMPL_NS_END
 #endif
 
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 #ifdef PUGIXML_COMPACT
 	static const uintptr_t xml_memory_block_alignment = 4;
 #else
@@ -444,16 +480,16 @@ PUGI__NS_BEGIN
 	static const uintptr_t xml_memory_page_value_allocated_or_shared_mask = xml_memory_page_value_allocated_mask | xml_memory_page_contents_shared_mask;
 
 #ifdef PUGIXML_COMPACT
-	#define PUGI__GETHEADER_IMPL(object, page, flags) // unused
-	#define PUGI__GETPAGE_IMPL(header) (header).get_page()
+	#define PUGI_IMPL_GETHEADER_IMPL(object, page, flags) // unused
+	#define PUGI_IMPL_GETPAGE_IMPL(header) (header).get_page()
 #else
-	#define PUGI__GETHEADER_IMPL(object, page, flags) (((reinterpret_cast<char*>(object) - reinterpret_cast<char*>(page)) << 8) | (flags))
+	#define PUGI_IMPL_GETHEADER_IMPL(object, page, flags) (((reinterpret_cast<char*>(object) - reinterpret_cast<char*>(page)) << 8) | (flags))
 	// this macro casts pointers through void* to avoid 'cast increases required alignment of target type' warnings
-	#define PUGI__GETPAGE_IMPL(header) static_cast<impl::xml_memory_page*>(const_cast<void*>(static_cast<const void*>(reinterpret_cast<const char*>(&header) - (header >> 8))))
+	#define PUGI_IMPL_GETPAGE_IMPL(header) static_cast<impl::xml_memory_page*>(const_cast<void*>(static_cast<const void*>(reinterpret_cast<const char*>(&header) - (header >> 8))))
 #endif
 
-	#define PUGI__GETPAGE(n) PUGI__GETPAGE_IMPL((n)->header)
-	#define PUGI__NODETYPE(n) static_cast<xml_node_type>((n)->header & impl::xml_memory_page_type_mask)
+	#define PUGI_IMPL_GETPAGE(n) PUGI_IMPL_GETPAGE_IMPL((n)->header)
+	#define PUGI_IMPL_NODETYPE(n) static_cast<xml_node_type>((n)->header & impl::xml_memory_page_type_mask)
 
 	struct xml_allocator;
 
@@ -463,16 +499,16 @@ PUGI__NS_BEGIN
 		{
 			xml_memory_page* result = static_cast<xml_memory_page*>(memory);
 
-			result->allocator = 0;
-			result->prev = 0;
-			result->next = 0;
+			result->allocator = nullptr;
+			result->prev = nullptr;
+			result->next = nullptr;
 			result->busy_size = 0;
 			result->freed_size = 0;
 
 		#ifdef PUGIXML_COMPACT
-			result->compact_string_base = 0;
-			result->compact_shared_parent = 0;
-			result->compact_page_marker = 0;
+			result->compact_string_base = nullptr;
+			result->compact_shared_parent = nullptr;
+			result->compact_page_marker = nullptr;
 		#endif
 
 			return result;
@@ -512,7 +548,7 @@ PUGI__NS_BEGIN
 		xml_allocator(xml_memory_page* root): _root(root), _busy_size(root->busy_size)
 		{
 		#ifdef PUGIXML_COMPACT
-			_hash = 0;
+			_hash = nullptr;
 		#endif
 		}
 
@@ -522,7 +558,7 @@ PUGI__NS_BEGIN
 
 			// allocate block with some alignment, leaving memory for worst-case padding
 			void* memory = xml_memory::allocate(size);
-			if (!memory) return 0;
+			if (!memory) return nullptr;
 
 			// prepare page structure
 			xml_memory_page* page = xml_memory_page::construct(memory);
@@ -543,7 +579,7 @@ PUGI__NS_BEGIN
 
 		void* allocate_memory(size_t size, xml_memory_page*& out_page)
 		{
-			if (PUGI__UNLIKELY(_busy_size + size > xml_memory_page_size))
+			if (PUGI_IMPL_UNLIKELY(_busy_size + size > xml_memory_page_size))
 				return allocate_memory_oob(size, out_page);
 
 			void* buf = reinterpret_cast<char*>(_root) + sizeof(xml_memory_page) + _busy_size;
@@ -559,12 +595,12 @@ PUGI__NS_BEGIN
 		void* allocate_object(size_t size, xml_memory_page*& out_page)
 		{
 			void* result = allocate_memory(size + sizeof(uint32_t), out_page);
-			if (!result) return 0;
+			if (!result) return nullptr;
 
 			// adjust for marker
 			ptrdiff_t offset = static_cast<char*>(result) - reinterpret_cast<char*>(out_page->compact_page_marker);
 
-			if (PUGI__UNLIKELY(static_cast<uintptr_t>(offset) >= 256 * xml_memory_block_alignment))
+			if (PUGI_IMPL_UNLIKELY(static_cast<uintptr_t>(offset) >= 256 * xml_memory_block_alignment))
 			{
 				// insert new marker
 				uint32_t* marker = static_cast<uint32_t*>(result);
@@ -605,7 +641,7 @@ PUGI__NS_BEGIN
 
 			if (page->freed_size == page->busy_size)
 			{
-				if (page->next == 0)
+				if (page->next == nullptr)
 				{
 					assert(_root == page);
 
@@ -615,9 +651,9 @@ PUGI__NS_BEGIN
 
 				#ifdef PUGIXML_COMPACT
 					// reset compact state to maximize efficiency
-					page->compact_string_base = 0;
-					page->compact_shared_parent = 0;
-					page->compact_page_marker = 0;
+					page->compact_string_base = nullptr;
+					page->compact_shared_parent = nullptr;
+					page->compact_page_marker = nullptr;
 				#endif
 
 					_busy_size = 0;
@@ -641,7 +677,7 @@ PUGI__NS_BEGIN
 		{
 			static const size_t max_encoded_offset = (1 << 16) * xml_memory_block_alignment;
 
-			PUGI__STATIC_ASSERT(xml_memory_page_size <= max_encoded_offset);
+			PUGI_IMPL_STATIC_ASSERT(xml_memory_page_size <= max_encoded_offset);
 
 			// allocate memory for string and header block
 			size_t size = sizeof(xml_memory_string_header) + length * sizeof(char_t);
@@ -652,7 +688,7 @@ PUGI__NS_BEGIN
 			xml_memory_page* page;
 			xml_memory_string_header* header = static_cast<xml_memory_string_header*>(allocate_memory(full_size, page));
 
-			if (!header) return 0;
+			if (!header) return nullptr;
 
 			// setup header
 			ptrdiff_t page_offset = reinterpret_cast<char*>(header) - reinterpret_cast<char*>(page) - sizeof(xml_memory_page);
@@ -707,14 +743,14 @@ PUGI__NS_BEGIN
 	#endif
 	};
 
-	PUGI__FN_NO_INLINE void* xml_allocator::allocate_memory_oob(size_t size, xml_memory_page*& out_page)
+	PUGI_IMPL_FN_NO_INLINE void* xml_allocator::allocate_memory_oob(size_t size, xml_memory_page*& out_page)
 	{
 		const size_t large_allocation_threshold = xml_memory_page_size / 4;
 
 		xml_memory_page* page = allocate_page(size <= large_allocation_threshold ? xml_memory_page_size : size);
 		out_page = page;
 
-		if (!page) return 0;
+		if (!page) return nullptr;
 
 		if (size <= large_allocation_threshold)
 		{
@@ -744,10 +780,10 @@ PUGI__NS_BEGIN
 
 		return reinterpret_cast<char*>(page) + sizeof(xml_memory_page);
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 #ifdef PUGIXML_COMPACT
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	static const uintptr_t compact_alignment_log2 = 2;
 	static const uintptr_t compact_alignment = 1 << compact_alignment_log2;
 
@@ -756,7 +792,7 @@ PUGI__NS_BEGIN
 	public:
 		compact_header(xml_memory_page* page, unsigned int flags)
 		{
-			PUGI__STATIC_ASSERT(xml_memory_block_alignment == compact_alignment);
+			PUGI_IMPL_STATIC_ASSERT(xml_memory_block_alignment == compact_alignment);
 
 			ptrdiff_t offset = (reinterpret_cast<char*>(this) - reinterpret_cast<char*>(page->compact_page_marker));
 			assert(offset % compact_alignment == 0 && static_cast<uintptr_t>(offset) < 256 * compact_alignment);
@@ -794,19 +830,19 @@ PUGI__NS_BEGIN
 		unsigned char _flags;
 	};
 
-	PUGI__FN xml_memory_page* compact_get_page(const void* object, int header_offset)
+	PUGI_IMPL_FN xml_memory_page* compact_get_page(const void* object, int header_offset)
 	{
 		const compact_header* header = reinterpret_cast<const compact_header*>(static_cast<const char*>(object) - header_offset);
 
 		return header->get_page();
 	}
 
-	template <int header_offset, typename T> PUGI__FN_NO_INLINE T* compact_get_value(const void* object)
+	template <int header_offset, typename T> PUGI_IMPL_FN_NO_INLINE T* compact_get_value(const void* object)
 	{
 		return static_cast<T*>(compact_get_page(object, header_offset)->allocator->_hash->find(object));
 	}
 
-	template <int header_offset, typename T> PUGI__FN_NO_INLINE void compact_set_value(const void* object, T* value)
+	template <int header_offset, typename T> PUGI_IMPL_FN_NO_INLINE void compact_set_value(const void* object, T* value)
 	{
 		compact_get_page(object, header_offset)->allocator->_hash->insert(object, value);
 	}
@@ -861,7 +897,7 @@ PUGI__NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return 0;
+				return nullptr;
 		}
 
 		T* operator->() const
@@ -904,7 +940,7 @@ PUGI__NS_BEGIN
 				{
 					xml_memory_page* page = compact_get_page(this, header_offset);
 
-					if (PUGI__UNLIKELY(page->compact_shared_parent == 0))
+					if (PUGI_IMPL_UNLIKELY(page->compact_shared_parent == nullptr))
 						page->compact_shared_parent = value;
 
 					if (page->compact_shared_parent == value)
@@ -941,7 +977,7 @@ PUGI__NS_BEGIN
 					return compact_get_value<header_offset, T>(this);
 			}
 			else
-				return 0;
+				return nullptr;
 		}
 
 		T* operator->() const
@@ -971,7 +1007,7 @@ PUGI__NS_BEGIN
 			{
 				xml_memory_page* page = compact_get_page(this, header_offset);
 
-				if (PUGI__UNLIKELY(page->compact_string_base == 0))
+				if (PUGI_IMPL_UNLIKELY(page->compact_string_base == nullptr))
 					page->compact_string_base = value;
 
 				ptrdiff_t offset = value - page->compact_string_base;
@@ -1037,13 +1073,13 @@ PUGI__NS_BEGIN
 				}
 			}
 			else
-				return 0;
+				return nullptr;
 		}
 
 	private:
 		unsigned char _data;
 	};
-PUGI__NS_END
+PUGI_IMPL_NS_END
 #endif
 
 #ifdef PUGIXML_COMPACT
@@ -1053,7 +1089,7 @@ namespace pugi
 	{
 		xml_attribute_struct(impl::xml_memory_page* page): header(page, 0), namevalue_base(0)
 		{
-			PUGI__STATIC_ASSERT(sizeof(xml_attribute_struct) == 8);
+			PUGI_IMPL_STATIC_ASSERT(sizeof(xml_attribute_struct) == 8);
 		}
 
 		impl::compact_header header;
@@ -1071,7 +1107,7 @@ namespace pugi
 	{
 		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): header(page, type), namevalue_base(0)
 		{
-			PUGI__STATIC_ASSERT(sizeof(xml_node_struct) == 12);
+			PUGI_IMPL_STATIC_ASSERT(sizeof(xml_node_struct) == 12);
 		}
 
 		impl::compact_header header;
@@ -1096,9 +1132,9 @@ namespace pugi
 {
 	struct xml_attribute_struct
 	{
-		xml_attribute_struct(impl::xml_memory_page* page): name(0), value(0), prev_attribute_c(0), next_attribute(0)
+		xml_attribute_struct(impl::xml_memory_page* page): name(nullptr), value(nullptr), prev_attribute_c(nullptr), next_attribute(nullptr)
 		{
-			header = PUGI__GETHEADER_IMPL(this, page, 0);
+			header = PUGI_IMPL_GETHEADER_IMPL(this, page, 0);
 		}
 
 		uintptr_t header;
@@ -1112,9 +1148,9 @@ namespace pugi
 
 	struct xml_node_struct
 	{
-		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(0), value(0), parent(0), first_child(0), prev_sibling_c(0), next_sibling(0), first_attribute(0)
+		xml_node_struct(impl::xml_memory_page* page, xml_node_type type): name(nullptr), value(nullptr), parent(nullptr), first_child(nullptr), prev_sibling_c(nullptr), next_sibling(nullptr), first_attribute(nullptr)
 		{
-			header = PUGI__GETHEADER_IMPL(this, page, type);
+			header = PUGI_IMPL_GETHEADER_IMPL(this, page, type);
 		}
 
 		uintptr_t header;
@@ -1134,7 +1170,7 @@ namespace pugi
 }
 #endif
 
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	struct xml_extra_buffer
 	{
 		char_t* buffer;
@@ -1143,7 +1179,7 @@ PUGI__NS_BEGIN
 
 	struct xml_document_struct: public xml_node_struct, public xml_allocator
 	{
-		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(0), extra_buffers(0)
+		xml_document_struct(xml_memory_page* page): xml_node_struct(page, node_document), xml_allocator(page), buffer(nullptr), extra_buffers(nullptr)
 		{
 		}
 
@@ -1160,24 +1196,24 @@ PUGI__NS_BEGIN
 	{
 		assert(object);
 
-		return *PUGI__GETPAGE(object)->allocator;
+		return *PUGI_IMPL_GETPAGE(object)->allocator;
 	}
 
 	template <typename Object> inline xml_document_struct& get_document(const Object* object)
 	{
 		assert(object);
 
-		return *static_cast<xml_document_struct*>(PUGI__GETPAGE(object)->allocator);
+		return *static_cast<xml_document_struct*>(PUGI_IMPL_GETPAGE(object)->allocator);
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // Low-level DOM operations
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	inline xml_attribute_struct* allocate_attribute(xml_allocator& alloc)
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_attribute_struct), page);
-		if (!memory) return 0;
+		if (!memory) return nullptr;
 
 		return new (memory) xml_attribute_struct(page);
 	}
@@ -1186,7 +1222,7 @@ PUGI__NS_BEGIN
 	{
 		xml_memory_page* page;
 		void* memory = alloc.allocate_object(sizeof(xml_node_struct), page);
-		if (!memory) return 0;
+		if (!memory) return nullptr;
 
 		return new (memory) xml_node_struct(page, type);
 	}
@@ -1199,7 +1235,7 @@ PUGI__NS_BEGIN
 		if (a->header & impl::xml_memory_page_value_allocated_mask)
 			alloc.deallocate_string(a->value);
 
-		alloc.deallocate_memory(a, sizeof(xml_attribute_struct), PUGI__GETPAGE(a));
+		alloc.deallocate_memory(a, sizeof(xml_attribute_struct), PUGI_IMPL_GETPAGE(a));
 	}
 
 	inline void destroy_node(xml_node_struct* n, xml_allocator& alloc)
@@ -1228,7 +1264,7 @@ PUGI__NS_BEGIN
 			child = next;
 		}
 
-		alloc.deallocate_memory(n, sizeof(xml_node_struct), PUGI__GETPAGE(n));
+		alloc.deallocate_memory(n, sizeof(xml_node_struct), PUGI_IMPL_GETPAGE(n));
 	}
 
 	inline void append_node(xml_node_struct* child, xml_node_struct* node)
@@ -1325,9 +1361,9 @@ PUGI__NS_BEGIN
 		else
 			parent->first_child = next;
 
-		node->parent = 0;
-		node->prev_sibling_c = 0;
-		node->next_sibling = 0;
+		node->parent = nullptr;
+		node->prev_sibling_c = nullptr;
+		node->next_sibling = nullptr;
 	}
 
 	inline void append_attribute(xml_attribute_struct* attr, xml_node_struct* node)
@@ -1408,37 +1444,37 @@ PUGI__NS_BEGIN
 		else
 			node->first_attribute = next;
 
-		attr->prev_attribute_c = 0;
-		attr->next_attribute = 0;
+		attr->prev_attribute_c = nullptr;
+		attr->next_attribute = nullptr;
 	}
 
-	PUGI__FN_NO_INLINE xml_node_struct* append_new_node(xml_node_struct* node, xml_allocator& alloc, xml_node_type type = node_element)
+	PUGI_IMPL_FN_NO_INLINE xml_node_struct* append_new_node(xml_node_struct* node, xml_allocator& alloc, xml_node_type type = node_element)
 	{
-		if (!alloc.reserve()) return 0;
+		if (!alloc.reserve()) return nullptr;
 
 		xml_node_struct* child = allocate_node(alloc, type);
-		if (!child) return 0;
+		if (!child) return nullptr;
 
 		append_node(child, node);
 
 		return child;
 	}
 
-	PUGI__FN_NO_INLINE xml_attribute_struct* append_new_attribute(xml_node_struct* node, xml_allocator& alloc)
+	PUGI_IMPL_FN_NO_INLINE xml_attribute_struct* append_new_attribute(xml_node_struct* node, xml_allocator& alloc)
 	{
-		if (!alloc.reserve()) return 0;
+		if (!alloc.reserve()) return nullptr;
 
 		xml_attribute_struct* attr = allocate_attribute(alloc);
-		if (!attr) return 0;
+		if (!attr) return nullptr;
 
 		append_attribute(attr, node);
 
 		return attr;
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // Helper classes for code generation
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	struct opt_false
 	{
 		enum { value = 0 };
@@ -1448,10 +1484,10 @@ PUGI__NS_BEGIN
 	{
 		enum { value = 1 };
 	};
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // Unicode utilities
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	inline uint16_t endian_swap(uint16_t value)
 	{
 		return static_cast<uint16_t>(((value & 0xff) << 8) | (value >> 8));
@@ -1556,8 +1592,8 @@ PUGI__NS_BEGIN
 
 		static value_type high(value_type result, uint32_t ch)
 		{
-			uint32_t msh = static_cast<uint32_t>(ch - 0x10000) >> 10;
-			uint32_t lsh = static_cast<uint32_t>(ch - 0x10000) & 0x3ff;
+			uint32_t msh = (ch - 0x10000U) >> 10;
+			uint32_t lsh = (ch - 0x10000U) & 0x3ff;
 
 			result[0] = static_cast<uint16_t>(0xD800 + msh);
 			result[1] = static_cast<uint16_t>(0xDC00 + lsh);
@@ -1833,15 +1869,15 @@ PUGI__NS_BEGIN
 	};
 
 #ifdef PUGIXML_WCHAR_MODE
-	PUGI__FN void convert_wchar_endian_swap(wchar_t* result, const wchar_t* data, size_t length)
+	PUGI_IMPL_FN void convert_wchar_endian_swap(wchar_t* result, const wchar_t* data, size_t length)
 	{
 		for (size_t i = 0; i < length; ++i)
 			result[i] = static_cast<wchar_t>(endian_swap(static_cast<wchar_selector<sizeof(wchar_t)>::type>(data[i])));
 	}
 #endif
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	enum chartype_t
 	{
 		ct_parse_pcdata = 1,	// \0, &, \r, <
@@ -1854,7 +1890,7 @@ PUGI__NS_BEGIN
 		ct_start_symbol = 128	// Any symbol > 127, a-z, A-Z, _, :
 	};
 
-	static const unsigned char chartype_table[256] =
+	static constexpr unsigned char chartype_table[256] =
 	{
 		55,  0,   0,   0,   0,   0,   0,   0,      0,   12,  12,  0,   0,   63,  0,   0,   // 0-15
 		0,   0,   0,   0,   0,   0,   0,   0,      0,   0,   0,   0,   0,   0,   0,   0,   // 16-31
@@ -1884,7 +1920,7 @@ PUGI__NS_BEGIN
 		ctx_symbol = 16			  // Any symbol > 127, a-z, A-Z, 0-9, _, -, .
 	};
 
-	static const unsigned char chartypex_table[256] =
+	static constexpr unsigned char chartypex_table[256] =
 	{
 		3,  3,  3,  3,  3,  3,  3,  3,     3,  2,  2,  3,  3,  2,  3,  3,     // 0-15
 		3,  3,  3,  3,  3,  3,  3,  3,     3,  3,  3,  3,  3,  3,  3,  3,     // 16-31
@@ -1907,24 +1943,24 @@ PUGI__NS_BEGIN
 	};
 
 #ifdef PUGIXML_WCHAR_MODE
-	#define PUGI__IS_CHARTYPE_IMPL(c, ct, table) ((static_cast<unsigned int>(c) < 128 ? table[static_cast<unsigned int>(c)] : table[128]) & (ct))
+	#define PUGI_IMPL_IS_CHARTYPE_IMPL(c, ct, table) ((static_cast<unsigned int>(c) < 128 ? table[static_cast<unsigned int>(c)] : table[128]) & (ct))
 #else
-	#define PUGI__IS_CHARTYPE_IMPL(c, ct, table) (table[static_cast<unsigned char>(c)] & (ct))
+	#define PUGI_IMPL_IS_CHARTYPE_IMPL(c, ct, table) (table[static_cast<unsigned char>(c)] & (ct))
 #endif
 
-	#define PUGI__IS_CHARTYPE(c, ct) PUGI__IS_CHARTYPE_IMPL(c, ct, chartype_table)
-	#define PUGI__IS_CHARTYPEX(c, ct) PUGI__IS_CHARTYPE_IMPL(c, ct, chartypex_table)
+	#define PUGI_IMPL_IS_CHARTYPE(c, ct) PUGI_IMPL_IS_CHARTYPE_IMPL(c, ct, chartype_table)
+	#define PUGI_IMPL_IS_CHARTYPEX(c, ct) PUGI_IMPL_IS_CHARTYPE_IMPL(c, ct, chartypex_table)
 
-	PUGI__FN bool is_little_endian()
+	PUGI_IMPL_FN bool is_little_endian()
 	{
 		unsigned int ui = 1;
 
 		return *reinterpret_cast<unsigned char*>(&ui) == 1;
 	}
 
-	PUGI__FN xml_encoding get_wchar_encoding()
+	PUGI_IMPL_FN xml_encoding get_wchar_encoding()
 	{
-		PUGI__STATIC_ASSERT(sizeof(wchar_t) == 2 || sizeof(wchar_t) == 4);
+		PUGI_IMPL_STATIC_ASSERT(sizeof(wchar_t) == 2 || sizeof(wchar_t) == 4);
 
 		if (sizeof(wchar_t) == 2)
 			return is_little_endian() ? encoding_utf16_le : encoding_utf16_be;
@@ -1932,13 +1968,13 @@ PUGI__NS_BEGIN
 			return is_little_endian() ? encoding_utf32_le : encoding_utf32_be;
 	}
 
-	PUGI__FN bool parse_declaration_encoding(const uint8_t* data, size_t size, const uint8_t*& out_encoding, size_t& out_length)
+	PUGI_IMPL_FN bool parse_declaration_encoding(const uint8_t* data, size_t size, const uint8_t*& out_encoding, size_t& out_length)
 	{
-	#define PUGI__SCANCHAR(ch) { if (offset >= size || data[offset] != ch) return false; offset++; }
-	#define PUGI__SCANCHARTYPE(ct) { while (offset < size && PUGI__IS_CHARTYPE(data[offset], ct)) offset++; }
+	#define PUGI_IMPL_SCANCHAR(ch) { if (offset >= size || data[offset] != ch) return false; offset++; }
+	#define PUGI_IMPL_SCANCHARTYPE(ct) { while (offset < size && PUGI_IMPL_IS_CHARTYPE(data[offset], ct)) offset++; }
 
 		// check if we have a non-empty XML declaration
-		if (size < 6 || !((data[0] == '<') & (data[1] == '?') & (data[2] == 'x') & (data[3] == 'm') & (data[4] == 'l') && PUGI__IS_CHARTYPE(data[5], ct_space)))
+		if (size < 6 || !((data[0] == '<') & (data[1] == '?') & (data[2] == 'x') & (data[3] == 'm') & (data[4] == 'l') && PUGI_IMPL_IS_CHARTYPE(data[5], ct_space)))
 			return false;
 
 		// scan XML declaration until the encoding field
@@ -1953,28 +1989,28 @@ PUGI__NS_BEGIN
 				size_t offset = i;
 
 				// encoding follows the version field which can't contain 'en' so this has to be the encoding if XML is well formed
-				PUGI__SCANCHAR('e'); PUGI__SCANCHAR('n'); PUGI__SCANCHAR('c'); PUGI__SCANCHAR('o');
-				PUGI__SCANCHAR('d'); PUGI__SCANCHAR('i'); PUGI__SCANCHAR('n'); PUGI__SCANCHAR('g');
+				PUGI_IMPL_SCANCHAR('e'); PUGI_IMPL_SCANCHAR('n'); PUGI_IMPL_SCANCHAR('c'); PUGI_IMPL_SCANCHAR('o');
+				PUGI_IMPL_SCANCHAR('d'); PUGI_IMPL_SCANCHAR('i'); PUGI_IMPL_SCANCHAR('n'); PUGI_IMPL_SCANCHAR('g');
 
 				// S? = S?
-				PUGI__SCANCHARTYPE(ct_space);
-				PUGI__SCANCHAR('=');
-				PUGI__SCANCHARTYPE(ct_space);
+				PUGI_IMPL_SCANCHARTYPE(ct_space);
+				PUGI_IMPL_SCANCHAR('=');
+				PUGI_IMPL_SCANCHARTYPE(ct_space);
 
 				// the only two valid delimiters are ' and "
 				uint8_t delimiter = (offset < size && data[offset] == '"') ? '"' : '\'';
 
-				PUGI__SCANCHAR(delimiter);
+				PUGI_IMPL_SCANCHAR(delimiter);
 
 				size_t start = offset;
 
 				out_encoding = data + offset;
 
-				PUGI__SCANCHARTYPE(ct_symbol);
+				PUGI_IMPL_SCANCHARTYPE(ct_symbol);
 
 				out_length = offset - start;
 
-				PUGI__SCANCHAR(delimiter);
+				PUGI_IMPL_SCANCHAR(delimiter);
 
 				return true;
 			}
@@ -1982,11 +2018,11 @@ PUGI__NS_BEGIN
 
 		return false;
 
-	#undef PUGI__SCANCHAR
-	#undef PUGI__SCANCHARTYPE
+	#undef PUGI_IMPL_SCANCHAR
+	#undef PUGI_IMPL_SCANCHARTYPE
 	}
 
-	PUGI__FN xml_encoding guess_buffer_encoding(const uint8_t* data, size_t size)
+	PUGI_IMPL_FN xml_encoding guess_buffer_encoding(const uint8_t* data, size_t size)
 	{
 		// skip encoding autodetection if input buffer is too small
 		if (size < 4) return encoding_utf8;
@@ -2011,7 +2047,7 @@ PUGI__NS_BEGIN
 		if (d0 == 0x3c && d1 == 0) return encoding_utf16_le;
 
 		// no known BOM detected; parse declaration
-		const uint8_t* enc = 0;
+		const uint8_t* enc = nullptr;
 		size_t enc_length = 0;
 
 		if (d0 == 0x3c && d1 == 0x3f && d2 == 0x78 && d3 == 0x6d && parse_declaration_encoding(data, size, enc, enc_length))
@@ -2034,7 +2070,7 @@ PUGI__NS_BEGIN
 		return encoding_utf8;
 	}
 
-	PUGI__FN xml_encoding get_buffer_encoding(xml_encoding encoding, const void* contents, size_t size)
+	PUGI_IMPL_FN xml_encoding get_buffer_encoding(xml_encoding encoding, const void* contents, size_t size)
 	{
 		// replace wchar encoding with utf implementation
 		if (encoding == encoding_wchar) return get_wchar_encoding();
@@ -2054,7 +2090,7 @@ PUGI__NS_BEGIN
 		return guess_buffer_encoding(data, size);
 	}
 
-	PUGI__FN bool get_mutable_buffer(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, bool is_mutable)
+	PUGI_IMPL_FN bool get_mutable_buffer(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, bool is_mutable)
 	{
 		size_t length = size / sizeof(char_t);
 
@@ -2083,13 +2119,13 @@ PUGI__NS_BEGIN
 	}
 
 #ifdef PUGIXML_WCHAR_MODE
-	PUGI__FN bool need_endian_swap_utf(xml_encoding le, xml_encoding re)
+	PUGI_IMPL_FN bool need_endian_swap_utf(xml_encoding le, xml_encoding re)
 	{
 		return (le == encoding_utf16_be && re == encoding_utf16_le) || (le == encoding_utf16_le && re == encoding_utf16_be) ||
 			   (le == encoding_utf32_be && re == encoding_utf32_le) || (le == encoding_utf32_le && re == encoding_utf32_be);
 	}
 
-	PUGI__FN bool convert_buffer_endian_swap(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, bool is_mutable)
+	PUGI_IMPL_FN bool convert_buffer_endian_swap(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, bool is_mutable)
 	{
 		const char_t* data = static_cast<const char_t*>(contents);
 		size_t length = size / sizeof(char_t);
@@ -2118,7 +2154,7 @@ PUGI__NS_BEGIN
 		return true;
 	}
 
-	template <typename D> PUGI__FN bool convert_buffer_generic(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, D)
+	template <typename D> PUGI_IMPL_FN bool convert_buffer_generic(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, D)
 	{
 		const typename D::type* data = static_cast<const typename D::type*>(contents);
 		size_t data_length = size / sizeof(typename D::type);
@@ -2143,7 +2179,7 @@ PUGI__NS_BEGIN
 		return true;
 	}
 
-	PUGI__FN bool convert_buffer(char_t*& out_buffer, size_t& out_length, xml_encoding encoding, const void* contents, size_t size, bool is_mutable)
+	PUGI_IMPL_FN bool convert_buffer(char_t*& out_buffer, size_t& out_length, xml_encoding encoding, const void* contents, size_t size, bool is_mutable)
 	{
 		// get native encoding
 		xml_encoding wchar_encoding = get_wchar_encoding();
@@ -2188,7 +2224,7 @@ PUGI__NS_BEGIN
 		return false;
 	}
 #else
-	template <typename D> PUGI__FN bool convert_buffer_generic(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, D)
+	template <typename D> PUGI_IMPL_FN bool convert_buffer_generic(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, D)
 	{
 		const typename D::type* data = static_cast<const typename D::type*>(contents);
 		size_t data_length = size / sizeof(typename D::type);
@@ -2213,7 +2249,7 @@ PUGI__NS_BEGIN
 		return true;
 	}
 
-	PUGI__FN size_t get_latin1_7bit_prefix_length(const uint8_t* data, size_t size)
+	PUGI_IMPL_FN size_t get_latin1_7bit_prefix_length(const uint8_t* data, size_t size)
 	{
 		for (size_t i = 0; i < size; ++i)
 			if (data[i] > 127)
@@ -2222,7 +2258,7 @@ PUGI__NS_BEGIN
 		return size;
 	}
 
-	PUGI__FN bool convert_buffer_latin1(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, bool is_mutable)
+	PUGI_IMPL_FN bool convert_buffer_latin1(char_t*& out_buffer, size_t& out_length, const void* contents, size_t size, bool is_mutable)
 	{
 		const uint8_t* data = static_cast<const uint8_t*>(contents);
 		size_t data_length = size;
@@ -2259,7 +2295,7 @@ PUGI__NS_BEGIN
 		return true;
 	}
 
-	PUGI__FN bool convert_buffer(char_t*& out_buffer, size_t& out_length, xml_encoding encoding, const void* contents, size_t size, bool is_mutable)
+	PUGI_IMPL_FN bool convert_buffer(char_t*& out_buffer, size_t& out_length, xml_encoding encoding, const void* contents, size_t size, bool is_mutable)
 	{
 		// fast path: no conversion required
 		if (encoding == encoding_utf8)
@@ -2294,13 +2330,13 @@ PUGI__NS_BEGIN
 	}
 #endif
 
-	PUGI__FN size_t as_utf8_begin(const wchar_t* str, size_t length)
+	PUGI_IMPL_FN size_t as_utf8_begin(const wchar_t* str, size_t length)
 	{
 		// get length in utf8 characters
 		return wchar_decoder::process(str, length, 0, utf8_counter());
 	}
 
-	PUGI__FN void as_utf8_end(char* buffer, size_t size, const wchar_t* str, size_t length)
+	PUGI_IMPL_FN void as_utf8_end(char* buffer, size_t size, const wchar_t* str, size_t length)
 	{
 		// convert to utf8
 		uint8_t* begin = reinterpret_cast<uint8_t*>(buffer);
@@ -2312,7 +2348,7 @@ PUGI__NS_BEGIN
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN std::string as_utf8_impl(const wchar_t* str, size_t length)
+	PUGI_IMPL_FN std::string as_utf8_impl(const wchar_t* str, size_t length)
 	{
 		// first pass: get length in utf8 characters
 		size_t size = as_utf8_begin(str, length);
@@ -2327,7 +2363,7 @@ PUGI__NS_BEGIN
 		return result;
 	}
 
-	PUGI__FN std::basic_string<wchar_t> as_wide_impl(const char* str, size_t size)
+	PUGI_IMPL_FN std::basic_string<wchar_t> as_wide_impl(const char* str, size_t size)
 	{
 		const uint8_t* data = reinterpret_cast<const uint8_t*>(str);
 
@@ -2370,17 +2406,19 @@ PUGI__NS_BEGIN
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool strcpy_insitu(String& dest, Header& header, uintptr_t header_mask, const char_t* source, size_t source_length)
+	PUGI_IMPL_FN bool strcpy_insitu(String& dest, Header& header, uintptr_t header_mask, const char_t* source, size_t source_length)
 	{
+		assert((header & header_mask) == 0 || dest); // header bit indicates whether dest was previously allocated
+
 		if (source_length == 0)
 		{
 			// empty string and null pointer are equivalent, so just deallocate old memory
-			xml_allocator* alloc = PUGI__GETPAGE_IMPL(header)->allocator;
+			xml_allocator* alloc = PUGI_IMPL_GETPAGE_IMPL(header)->allocator;
 
 			if (header & header_mask) alloc->deallocate_string(dest);
 
 			// mark the string as not allocated
-			dest = 0;
+			dest = nullptr;
 			header &= ~header_mask;
 
 			return true;
@@ -2395,7 +2433,7 @@ PUGI__NS_BEGIN
 		}
 		else
 		{
-			xml_allocator* alloc = PUGI__GETPAGE_IMPL(header)->allocator;
+			xml_allocator* alloc = PUGI_IMPL_GETPAGE_IMPL(header)->allocator;
 
 			if (!alloc->reserve()) return false;
 
@@ -2423,7 +2461,7 @@ PUGI__NS_BEGIN
 		char_t* end;
 		size_t size;
 
-		gap(): end(0), size(0)
+		gap(): end(nullptr), size(0)
 		{
 		}
 
@@ -2435,7 +2473,7 @@ PUGI__NS_BEGIN
 			{
 				// Move [old_gap_end, new_gap_start) to [old_gap_start, ...)
 				assert(s >= end);
-				memmove(end - size, end, reinterpret_cast<char*>(s) - reinterpret_cast<char*>(end));
+				memmove(end - size, end, (s - end) * sizeof(char_t));
 			}
 
 			s += count; // end of current gap
@@ -2452,7 +2490,7 @@ PUGI__NS_BEGIN
 			{
 				// Move [old_gap_end, current_pos) to [old_gap_start, ...)
 				assert(s >= end);
-				memmove(end - size, end, reinterpret_cast<char*>(s) - reinterpret_cast<char*>(end));
+				memmove(end - size, end, (s - end) * sizeof(char_t));
 
 				return s - size;
 			}
@@ -2460,7 +2498,7 @@ PUGI__NS_BEGIN
 		}
 	};
 
-	PUGI__FN char_t* strconv_escape(char_t* s, gap& g)
+	PUGI_IMPL_FN char_t* strconv_escape(char_t* s, gap& g)
 	{
 		char_t* stre = s + 1;
 
@@ -2601,25 +2639,25 @@ PUGI__NS_BEGIN
 	}
 
 	// Parser utilities
-	#define PUGI__ENDSWITH(c, e)        ((c) == (e) || ((c) == 0 && endch == (e)))
-	#define PUGI__SKIPWS()              { while (PUGI__IS_CHARTYPE(*s, ct_space)) ++s; }
-	#define PUGI__OPTSET(OPT)           ( optmsk & (OPT) )
-	#define PUGI__PUSHNODE(TYPE)        { cursor = append_new_node(cursor, *alloc, TYPE); if (!cursor) PUGI__THROW_ERROR(status_out_of_memory, s); }
-	#define PUGI__POPNODE()             { cursor = cursor->parent; }
-	#define PUGI__SCANFOR(X)            { while (*s != 0 && !(X)) ++s; }
-	#define PUGI__SCANWHILE(X)          { while (X) ++s; }
-	#define PUGI__SCANWHILE_UNROLL(X)   { for (;;) { char_t ss = s[0]; if (PUGI__UNLIKELY(!(X))) { break; } ss = s[1]; if (PUGI__UNLIKELY(!(X))) { s += 1; break; } ss = s[2]; if (PUGI__UNLIKELY(!(X))) { s += 2; break; } ss = s[3]; if (PUGI__UNLIKELY(!(X))) { s += 3; break; } s += 4; } }
-	#define PUGI__ENDSEG()              { ch = *s; *s = 0; ++s; }
-	#define PUGI__THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(0)
-	#define PUGI__CHECK_ERROR(err, m)   { if (*s == 0) PUGI__THROW_ERROR(err, m); }
+	#define PUGI_IMPL_ENDSWITH(c, e)        ((c) == (e) || ((c) == 0 && endch == (e)))
+	#define PUGI_IMPL_SKIPWS()              { while (PUGI_IMPL_IS_CHARTYPE(*s, ct_space)) ++s; }
+	#define PUGI_IMPL_OPTSET(OPT)           ( optmsk & (OPT) )
+	#define PUGI_IMPL_PUSHNODE(TYPE)        { cursor = append_new_node(cursor, *alloc, TYPE); if (!cursor) PUGI_IMPL_THROW_ERROR(status_out_of_memory, s); }
+	#define PUGI_IMPL_POPNODE()             { cursor = cursor->parent; }
+	#define PUGI_IMPL_SCANFOR(X)            { while (*s != 0 && !(X)) ++s; }
+	#define PUGI_IMPL_SCANWHILE(X)          { while (X) ++s; }
+	#define PUGI_IMPL_SCANWHILE_UNROLL(X)   { for (;;) { char_t ss = s[0]; if (PUGI_IMPL_UNLIKELY(!(X))) { break; } ss = s[1]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 1; break; } ss = s[2]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 2; break; } ss = s[3]; if (PUGI_IMPL_UNLIKELY(!(X))) { s += 3; break; } s += 4; } }
+	#define PUGI_IMPL_ENDSEG()              { ch = *s; *s = 0; ++s; }
+	#define PUGI_IMPL_THROW_ERROR(err, m)   return error_offset = m, error_status = err, static_cast<char_t*>(nullptr)
+	#define PUGI_IMPL_CHECK_ERROR(err, m)   { if (*s == 0) PUGI_IMPL_THROW_ERROR(err, m); }
 
-	PUGI__FN char_t* strconv_comment(char_t* s, char_t endch)
+	PUGI_IMPL_FN char_t* strconv_comment(char_t* s, char_t endch)
 	{
 		gap g;
 
 		while (true)
 		{
-			PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPE(ss, ct_parse_comment));
+			PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPE(ss, ct_parse_comment));
 
 			if (*s == '\r') // Either a single 0x0d or 0x0d 0x0a pair
 			{
@@ -2627,7 +2665,7 @@ PUGI__NS_BEGIN
 
 				if (*s == '\n') g.push(s, 1);
 			}
-			else if (s[0] == '-' && s[1] == '-' && PUGI__ENDSWITH(s[2], '>')) // comment ends here
+			else if (s[0] == '-' && s[1] == '-' && PUGI_IMPL_ENDSWITH(s[2], '>')) // comment ends here
 			{
 				*g.flush(s) = 0;
 
@@ -2635,19 +2673,19 @@ PUGI__NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return 0;
+				return nullptr;
 			}
 			else ++s;
 		}
 	}
 
-	PUGI__FN char_t* strconv_cdata(char_t* s, char_t endch)
+	PUGI_IMPL_FN char_t* strconv_cdata(char_t* s, char_t endch)
 	{
 		gap g;
 
 		while (true)
 		{
-			PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPE(ss, ct_parse_cdata));
+			PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPE(ss, ct_parse_cdata));
 
 			if (*s == '\r') // Either a single 0x0d or 0x0d 0x0a pair
 			{
@@ -2655,7 +2693,7 @@ PUGI__NS_BEGIN
 
 				if (*s == '\n') g.push(s, 1);
 			}
-			else if (s[0] == ']' && s[1] == ']' && PUGI__ENDSWITH(s[2], '>')) // CDATA ends here
+			else if (s[0] == ']' && s[1] == ']' && PUGI_IMPL_ENDSWITH(s[2], '>')) // CDATA ends here
 			{
 				*g.flush(s) = 0;
 
@@ -2663,7 +2701,7 @@ PUGI__NS_BEGIN
 			}
 			else if (*s == 0)
 			{
-				return 0;
+				return nullptr;
 			}
 			else ++s;
 		}
@@ -2681,14 +2719,14 @@ PUGI__NS_BEGIN
 
 			while (true)
 			{
-				PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPE(ss, ct_parse_pcdata));
+				PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPE(ss, ct_parse_pcdata));
 
 				if (*s == '<') // PCDATA ends here
 				{
 					char_t* end = g.flush(s);
 
 					if (opt_trim::value)
-						while (end > begin && PUGI__IS_CHARTYPE(end[-1], ct_space))
+						while (end > begin && PUGI_IMPL_IS_CHARTYPE(end[-1], ct_space))
 							--end;
 
 					*end = 0;
@@ -2710,7 +2748,7 @@ PUGI__NS_BEGIN
 					char_t* end = g.flush(s);
 
 					if (opt_trim::value)
-						while (end > begin && PUGI__IS_CHARTYPE(end[-1], ct_space))
+						while (end > begin && PUGI_IMPL_IS_CHARTYPE(end[-1], ct_space))
 							--end;
 
 					*end = 0;
@@ -2722,9 +2760,9 @@ PUGI__NS_BEGIN
 		}
 	};
 
-	PUGI__FN strconv_pcdata_t get_strconv_pcdata(unsigned int optmask)
+	PUGI_IMPL_FN strconv_pcdata_t get_strconv_pcdata(unsigned int optmask)
 	{
-		PUGI__STATIC_ASSERT(parse_escapes == 0x10 && parse_eol == 0x20 && parse_trim_pcdata == 0x0800);
+		PUGI_IMPL_STATIC_ASSERT(parse_escapes == 0x10 && parse_eol == 0x20 && parse_trim_pcdata == 0x0800);
 
 		switch (((optmask >> 4) & 3) | ((optmask >> 9) & 4)) // get bitmask for flags (trim eol escapes); this simultaneously checks 3 options from assertion above
 		{
@@ -2736,7 +2774,7 @@ PUGI__NS_BEGIN
 		case 5: return strconv_pcdata_impl<opt_true, opt_false, opt_true>::parse;
 		case 6: return strconv_pcdata_impl<opt_true, opt_true, opt_false>::parse;
 		case 7: return strconv_pcdata_impl<opt_true, opt_true, opt_true>::parse;
-		default: assert(false); return 0; // unreachable
+		default: assert(false); return nullptr; // unreachable
 		}
 	}
 
@@ -2749,37 +2787,37 @@ PUGI__NS_BEGIN
 			gap g;
 
 			// trim leading whitespaces
-			if (PUGI__IS_CHARTYPE(*s, ct_space))
+			if (PUGI_IMPL_IS_CHARTYPE(*s, ct_space))
 			{
 				char_t* str = s;
 
 				do ++str;
-				while (PUGI__IS_CHARTYPE(*str, ct_space));
+				while (PUGI_IMPL_IS_CHARTYPE(*str, ct_space));
 
 				g.push(s, str - s);
 			}
 
 			while (true)
 			{
-				PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPE(ss, ct_parse_attr_ws | ct_space));
+				PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPE(ss, ct_parse_attr_ws | ct_space));
 
 				if (*s == end_quote)
 				{
 					char_t* str = g.flush(s);
 
 					do *str-- = 0;
-					while (PUGI__IS_CHARTYPE(*str, ct_space));
+					while (PUGI_IMPL_IS_CHARTYPE(*str, ct_space));
 
 					return s + 1;
 				}
-				else if (PUGI__IS_CHARTYPE(*s, ct_space))
+				else if (PUGI_IMPL_IS_CHARTYPE(*s, ct_space))
 				{
 					*s++ = ' ';
 
-					if (PUGI__IS_CHARTYPE(*s, ct_space))
+					if (PUGI_IMPL_IS_CHARTYPE(*s, ct_space))
 					{
 						char_t* str = s + 1;
-						while (PUGI__IS_CHARTYPE(*str, ct_space)) ++str;
+						while (PUGI_IMPL_IS_CHARTYPE(*str, ct_space)) ++str;
 
 						g.push(s, str - s);
 					}
@@ -2790,7 +2828,7 @@ PUGI__NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return nullptr;
 				}
 				else ++s;
 			}
@@ -2802,7 +2840,7 @@ PUGI__NS_BEGIN
 
 			while (true)
 			{
-				PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPE(ss, ct_parse_attr_ws));
+				PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPE(ss, ct_parse_attr_ws));
 
 				if (*s == end_quote)
 				{
@@ -2810,7 +2848,7 @@ PUGI__NS_BEGIN
 
 					return s + 1;
 				}
-				else if (PUGI__IS_CHARTYPE(*s, ct_space))
+				else if (PUGI_IMPL_IS_CHARTYPE(*s, ct_space))
 				{
 					if (*s == '\r')
 					{
@@ -2826,7 +2864,7 @@ PUGI__NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return nullptr;
 				}
 				else ++s;
 			}
@@ -2838,7 +2876,7 @@ PUGI__NS_BEGIN
 
 			while (true)
 			{
-				PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPE(ss, ct_parse_attr));
+				PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPE(ss, ct_parse_attr));
 
 				if (*s == end_quote)
 				{
@@ -2858,7 +2896,7 @@ PUGI__NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return nullptr;
 				}
 				else ++s;
 			}
@@ -2870,7 +2908,7 @@ PUGI__NS_BEGIN
 
 			while (true)
 			{
-				PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPE(ss, ct_parse_attr));
+				PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPE(ss, ct_parse_attr));
 
 				if (*s == end_quote)
 				{
@@ -2884,16 +2922,16 @@ PUGI__NS_BEGIN
 				}
 				else if (!*s)
 				{
-					return 0;
+					return nullptr;
 				}
 				else ++s;
 			}
 		}
 	};
 
-	PUGI__FN strconv_attribute_t get_strconv_attribute(unsigned int optmask)
+	PUGI_IMPL_FN strconv_attribute_t get_strconv_attribute(unsigned int optmask)
 	{
-		PUGI__STATIC_ASSERT(parse_escapes == 0x10 && parse_eol == 0x20 && parse_wconv_attribute == 0x40 && parse_wnorm_attribute == 0x80);
+		PUGI_IMPL_STATIC_ASSERT(parse_escapes == 0x10 && parse_eol == 0x20 && parse_wconv_attribute == 0x40 && parse_wnorm_attribute == 0x80);
 
 		switch ((optmask >> 4) & 15) // get bitmask for flags (wnorm wconv eol escapes); this simultaneously checks 4 options from assertion above
 		{
@@ -2913,7 +2951,7 @@ PUGI__NS_BEGIN
 		case 13: return strconv_attribute_impl<opt_true>::parse_wnorm;
 		case 14: return strconv_attribute_impl<opt_false>::parse_wnorm;
 		case 15: return strconv_attribute_impl<opt_true>::parse_wnorm;
-		default: assert(false); return 0; // unreachable
+		default: assert(false); return nullptr; // unreachable
 		}
 	}
 
@@ -2932,7 +2970,7 @@ PUGI__NS_BEGIN
 		char_t* error_offset;
 		xml_parse_status error_status;
 
-		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(0), error_status(status_ok)
+		xml_parser(xml_allocator* alloc_): alloc(alloc_), error_offset(nullptr), error_status(status_ok)
 		{
 		}
 
@@ -2949,8 +2987,8 @@ PUGI__NS_BEGIN
 			{
 				// quoted string
 				char_t ch = *s++;
-				PUGI__SCANFOR(*s == ch);
-				if (!*s) PUGI__THROW_ERROR(status_bad_doctype, s);
+				PUGI_IMPL_SCANFOR(*s == ch);
+				if (!*s) PUGI_IMPL_THROW_ERROR(status_bad_doctype, s);
 
 				s++;
 			}
@@ -2958,20 +2996,20 @@ PUGI__NS_BEGIN
 			{
 				// <? ... ?>
 				s += 2;
-				PUGI__SCANFOR(s[0] == '?' && s[1] == '>'); // no need for ENDSWITH because ?> can't terminate proper doctype
-				if (!*s) PUGI__THROW_ERROR(status_bad_doctype, s);
+				PUGI_IMPL_SCANFOR(s[0] == '?' && s[1] == '>'); // no need for ENDSWITH because ?> can't terminate proper doctype
+				if (!*s) PUGI_IMPL_THROW_ERROR(status_bad_doctype, s);
 
 				s += 2;
 			}
 			else if (s[0] == '<' && s[1] == '!' && s[2] == '-' && s[3] == '-')
 			{
 				s += 4;
-				PUGI__SCANFOR(s[0] == '-' && s[1] == '-' && s[2] == '>'); // no need for ENDSWITH because --> can't terminate proper doctype
-				if (!*s) PUGI__THROW_ERROR(status_bad_doctype, s);
+				PUGI_IMPL_SCANFOR(s[0] == '-' && s[1] == '-' && s[2] == '>'); // no need for ENDSWITH because --> can't terminate proper doctype
+				if (!*s) PUGI_IMPL_THROW_ERROR(status_bad_doctype, s);
 
 				s += 3;
 			}
-			else PUGI__THROW_ERROR(status_bad_doctype, s);
+			else PUGI_IMPL_THROW_ERROR(status_bad_doctype, s);
 
 			return s;
 		}
@@ -3004,7 +3042,7 @@ PUGI__NS_BEGIN
 				else s++;
 			}
 
-			PUGI__THROW_ERROR(status_bad_doctype, s);
+			PUGI_IMPL_THROW_ERROR(status_bad_doctype, s);
 		}
 
 		char_t* parse_doctype_group(char_t* s, char_t endch)
@@ -3048,7 +3086,7 @@ PUGI__NS_BEGIN
 				else s++;
 			}
 
-			if (depth != 0 || endch != '>') PUGI__THROW_ERROR(status_bad_doctype, s);
+			if (depth != 0 || endch != '>') PUGI_IMPL_THROW_ERROR(status_bad_doctype, s);
 
 			return s;
 		}
@@ -3066,31 +3104,31 @@ PUGI__NS_BEGIN
 				{
 					++s;
 
-					if (PUGI__OPTSET(parse_comments))
+					if (PUGI_IMPL_OPTSET(parse_comments))
 					{
-						PUGI__PUSHNODE(node_comment); // Append a new node on the tree.
+						PUGI_IMPL_PUSHNODE(node_comment); // Append a new node on the tree.
 						cursor->value = s; // Save the offset.
 					}
 
-					if (PUGI__OPTSET(parse_eol) && PUGI__OPTSET(parse_comments))
+					if (PUGI_IMPL_OPTSET(parse_eol) && PUGI_IMPL_OPTSET(parse_comments))
 					{
 						s = strconv_comment(s, endch);
 
-						if (!s) PUGI__THROW_ERROR(status_bad_comment, cursor->value);
+						if (!s) PUGI_IMPL_THROW_ERROR(status_bad_comment, cursor->value);
 					}
 					else
 					{
 						// Scan for terminating '-->'.
-						PUGI__SCANFOR(s[0] == '-' && s[1] == '-' && PUGI__ENDSWITH(s[2], '>'));
-						PUGI__CHECK_ERROR(status_bad_comment, s);
+						PUGI_IMPL_SCANFOR(s[0] == '-' && s[1] == '-' && PUGI_IMPL_ENDSWITH(s[2], '>'));
+						PUGI_IMPL_CHECK_ERROR(status_bad_comment, s);
 
-						if (PUGI__OPTSET(parse_comments))
+						if (PUGI_IMPL_OPTSET(parse_comments))
 							*s = 0; // Zero-terminate this segment at the first terminating '-'.
 
 						s += (s[2] == '>' ? 3 : 2); // Step over the '\0->'.
 					}
 				}
-				else PUGI__THROW_ERROR(status_bad_comment, s);
+				else PUGI_IMPL_THROW_ERROR(status_bad_comment, s);
 			}
 			else if (*s == '[')
 			{
@@ -3099,22 +3137,22 @@ PUGI__NS_BEGIN
 				{
 					++s;
 
-					if (PUGI__OPTSET(parse_cdata))
+					if (PUGI_IMPL_OPTSET(parse_cdata))
 					{
-						PUGI__PUSHNODE(node_cdata); // Append a new node on the tree.
+						PUGI_IMPL_PUSHNODE(node_cdata); // Append a new node on the tree.
 						cursor->value = s; // Save the offset.
 
-						if (PUGI__OPTSET(parse_eol))
+						if (PUGI_IMPL_OPTSET(parse_eol))
 						{
 							s = strconv_cdata(s, endch);
 
-							if (!s) PUGI__THROW_ERROR(status_bad_cdata, cursor->value);
+							if (!s) PUGI_IMPL_THROW_ERROR(status_bad_cdata, cursor->value);
 						}
 						else
 						{
 							// Scan for terminating ']]>'.
-							PUGI__SCANFOR(s[0] == ']' && s[1] == ']' && PUGI__ENDSWITH(s[2], '>'));
-							PUGI__CHECK_ERROR(status_bad_cdata, s);
+							PUGI_IMPL_SCANFOR(s[0] == ']' && s[1] == ']' && PUGI_IMPL_ENDSWITH(s[2], '>'));
+							PUGI_IMPL_CHECK_ERROR(status_bad_cdata, s);
 
 							*s++ = 0; // Zero-terminate this segment.
 						}
@@ -3122,21 +3160,21 @@ PUGI__NS_BEGIN
 					else // Flagged for discard, but we still have to scan for the terminator.
 					{
 						// Scan for terminating ']]>'.
-						PUGI__SCANFOR(s[0] == ']' && s[1] == ']' && PUGI__ENDSWITH(s[2], '>'));
-						PUGI__CHECK_ERROR(status_bad_cdata, s);
+						PUGI_IMPL_SCANFOR(s[0] == ']' && s[1] == ']' && PUGI_IMPL_ENDSWITH(s[2], '>'));
+						PUGI_IMPL_CHECK_ERROR(status_bad_cdata, s);
 
 						++s;
 					}
 
 					s += (s[1] == '>' ? 2 : 1); // Step over the last ']>'.
 				}
-				else PUGI__THROW_ERROR(status_bad_cdata, s);
+				else PUGI_IMPL_THROW_ERROR(status_bad_cdata, s);
 			}
-			else if (s[0] == 'D' && s[1] == 'O' && s[2] == 'C' && s[3] == 'T' && s[4] == 'Y' && s[5] == 'P' && PUGI__ENDSWITH(s[6], 'E'))
+			else if (s[0] == 'D' && s[1] == 'O' && s[2] == 'C' && s[3] == 'T' && s[4] == 'Y' && s[5] == 'P' && PUGI_IMPL_ENDSWITH(s[6], 'E'))
 			{
 				s -= 2;
 
-				if (cursor->parent) PUGI__THROW_ERROR(status_bad_doctype, s);
+				if (cursor->parent) PUGI_IMPL_THROW_ERROR(status_bad_doctype, s);
 
 				char_t* mark = s + 9;
 
@@ -3146,18 +3184,18 @@ PUGI__NS_BEGIN
 				assert((*s == 0 && endch == '>') || *s == '>');
 				if (*s) *s++ = 0;
 
-				if (PUGI__OPTSET(parse_doctype))
+				if (PUGI_IMPL_OPTSET(parse_doctype))
 				{
-					while (PUGI__IS_CHARTYPE(*mark, ct_space)) ++mark;
+					while (PUGI_IMPL_IS_CHARTYPE(*mark, ct_space)) ++mark;
 
-					PUGI__PUSHNODE(node_doctype);
+					PUGI_IMPL_PUSHNODE(node_doctype);
 
 					cursor->value = mark;
 				}
 			}
-			else if (*s == 0 && endch == '-') PUGI__THROW_ERROR(status_bad_comment, s);
-			else if (*s == 0 && endch == '[') PUGI__THROW_ERROR(status_bad_cdata, s);
-			else PUGI__THROW_ERROR(status_unrecognized_tag, s);
+			else if (*s == 0 && endch == '-') PUGI_IMPL_THROW_ERROR(status_bad_comment, s);
+			else if (*s == 0 && endch == '[') PUGI_IMPL_THROW_ERROR(status_bad_cdata, s);
+			else PUGI_IMPL_THROW_ERROR(status_unrecognized_tag, s);
 
 			return s;
 		}
@@ -3174,50 +3212,50 @@ PUGI__NS_BEGIN
 			// read PI target
 			char_t* target = s;
 
-			if (!PUGI__IS_CHARTYPE(*s, ct_start_symbol)) PUGI__THROW_ERROR(status_bad_pi, s);
+			if (!PUGI_IMPL_IS_CHARTYPE(*s, ct_start_symbol)) PUGI_IMPL_THROW_ERROR(status_bad_pi, s);
 
-			PUGI__SCANWHILE(PUGI__IS_CHARTYPE(*s, ct_symbol));
-			PUGI__CHECK_ERROR(status_bad_pi, s);
+			PUGI_IMPL_SCANWHILE(PUGI_IMPL_IS_CHARTYPE(*s, ct_symbol));
+			PUGI_IMPL_CHECK_ERROR(status_bad_pi, s);
 
 			// determine node type; stricmp / strcasecmp is not portable
 			bool declaration = (target[0] | ' ') == 'x' && (target[1] | ' ') == 'm' && (target[2] | ' ') == 'l' && target + 3 == s;
 
-			if (declaration ? PUGI__OPTSET(parse_declaration) : PUGI__OPTSET(parse_pi))
+			if (declaration ? PUGI_IMPL_OPTSET(parse_declaration) : PUGI_IMPL_OPTSET(parse_pi))
 			{
 				if (declaration)
 				{
 					// disallow non top-level declarations
-					if (cursor->parent) PUGI__THROW_ERROR(status_bad_pi, s);
+					if (cursor->parent) PUGI_IMPL_THROW_ERROR(status_bad_pi, s);
 
-					PUGI__PUSHNODE(node_declaration);
+					PUGI_IMPL_PUSHNODE(node_declaration);
 				}
 				else
 				{
-					PUGI__PUSHNODE(node_pi);
+					PUGI_IMPL_PUSHNODE(node_pi);
 				}
 
 				cursor->name = target;
 
-				PUGI__ENDSEG();
+				PUGI_IMPL_ENDSEG();
 
 				// parse value/attributes
 				if (ch == '?')
 				{
 					// empty node
-					if (!PUGI__ENDSWITH(*s, '>')) PUGI__THROW_ERROR(status_bad_pi, s);
+					if (!PUGI_IMPL_ENDSWITH(*s, '>')) PUGI_IMPL_THROW_ERROR(status_bad_pi, s);
 					s += (*s == '>');
 
-					PUGI__POPNODE();
+					PUGI_IMPL_POPNODE();
 				}
-				else if (PUGI__IS_CHARTYPE(ch, ct_space))
+				else if (PUGI_IMPL_IS_CHARTYPE(ch, ct_space))
 				{
-					PUGI__SKIPWS();
+					PUGI_IMPL_SKIPWS();
 
 					// scan for tag end
 					char_t* value = s;
 
-					PUGI__SCANFOR(s[0] == '?' && PUGI__ENDSWITH(s[1], '>'));
-					PUGI__CHECK_ERROR(status_bad_pi, s);
+					PUGI_IMPL_SCANFOR(s[0] == '?' && PUGI_IMPL_ENDSWITH(s[1], '>'));
+					PUGI_IMPL_CHECK_ERROR(status_bad_pi, s);
 
 					if (declaration)
 					{
@@ -3232,20 +3270,20 @@ PUGI__NS_BEGIN
 						// store value and step over >
 						cursor->value = value;
 
-						PUGI__POPNODE();
+						PUGI_IMPL_POPNODE();
 
-						PUGI__ENDSEG();
+						PUGI_IMPL_ENDSEG();
 
 						s += (*s == '>');
 					}
 				}
-				else PUGI__THROW_ERROR(status_bad_pi, s);
+				else PUGI_IMPL_THROW_ERROR(status_bad_pi, s);
 			}
 			else
 			{
 				// scan for tag end
-				PUGI__SCANFOR(s[0] == '?' && PUGI__ENDSWITH(s[1], '>'));
-				PUGI__CHECK_ERROR(status_bad_pi, s);
+				PUGI_IMPL_SCANFOR(s[0] == '?' && PUGI_IMPL_ENDSWITH(s[1], '>'));
+				PUGI_IMPL_CHECK_ERROR(status_bad_pi, s);
 
 				s += (s[1] == '>' ? 2 : 1);
 			}
@@ -3264,6 +3302,7 @@ PUGI__NS_BEGIN
 			char_t ch = 0;
 			xml_node_struct* cursor = root;
 			char_t* mark = s;
+			char_t* merged_pcdata = s;
 
 			while (*s != 0)
 			{
@@ -3272,39 +3311,39 @@ PUGI__NS_BEGIN
 					++s;
 
 				LOC_TAG:
-					if (PUGI__IS_CHARTYPE(*s, ct_start_symbol)) // '<#...'
+					if (PUGI_IMPL_IS_CHARTYPE(*s, ct_start_symbol)) // '<#...'
 					{
-						PUGI__PUSHNODE(node_element); // Append a new node to the tree.
+						PUGI_IMPL_PUSHNODE(node_element); // Append a new node to the tree.
 
 						cursor->name = s;
 
-						PUGI__SCANWHILE_UNROLL(PUGI__IS_CHARTYPE(ss, ct_symbol)); // Scan for a terminator.
-						PUGI__ENDSEG(); // Save char in 'ch', terminate & step over.
+						PUGI_IMPL_SCANWHILE_UNROLL(PUGI_IMPL_IS_CHARTYPE(ss, ct_symbol)); // Scan for a terminator.
+						PUGI_IMPL_ENDSEG(); // Save char in 'ch', terminate & step over.
 
 						if (ch == '>')
 						{
 							// end of tag
 						}
-						else if (PUGI__IS_CHARTYPE(ch, ct_space))
+						else if (PUGI_IMPL_IS_CHARTYPE(ch, ct_space))
 						{
 						LOC_ATTRIBUTES:
 							while (true)
 							{
-								PUGI__SKIPWS(); // Eat any whitespace.
+								PUGI_IMPL_SKIPWS(); // Eat any whitespace.
 
-								if (PUGI__IS_CHARTYPE(*s, ct_start_symbol)) // <... #...
+								if (PUGI_IMPL_IS_CHARTYPE(*s, ct_start_symbol)) // <... #...
 								{
 									xml_attribute_struct* a = append_new_attribute(cursor, *alloc); // Make space for this attribute.
-									if (!a) PUGI__THROW_ERROR(status_out_of_memory, s);
+									if (!a) PUGI_IMPL_THROW_ERROR(status_out_of_memory, s);
 
 									a->name = s; // Save the offset.
 
-									PUGI__SCANWHILE_UNROLL(PUGI__IS_CHARTYPE(ss, ct_symbol)); // Scan for a terminator.
-									PUGI__ENDSEG(); // Save char in 'ch', terminate & step over.
+									PUGI_IMPL_SCANWHILE_UNROLL(PUGI_IMPL_IS_CHARTYPE(ss, ct_symbol)); // Scan for a terminator.
+									PUGI_IMPL_ENDSEG(); // Save char in 'ch', terminate & step over.
 
-									if (PUGI__IS_CHARTYPE(ch, ct_space))
+									if (PUGI_IMPL_IS_CHARTYPE(ch, ct_space))
 									{
-										PUGI__SKIPWS(); // Eat any whitespace.
+										PUGI_IMPL_SKIPWS(); // Eat any whitespace.
 
 										ch = *s;
 										++s;
@@ -3312,7 +3351,7 @@ PUGI__NS_BEGIN
 
 									if (ch == '=') // '<... #=...'
 									{
-										PUGI__SKIPWS(); // Eat any whitespace.
+										PUGI_IMPL_SKIPWS(); // Eat any whitespace.
 
 										if (*s == '"' || *s == '\'') // '<... #="...'
 										{
@@ -3322,16 +3361,16 @@ PUGI__NS_BEGIN
 
 											s = strconv_attribute(s, ch);
 
-											if (!s) PUGI__THROW_ERROR(status_bad_attribute, a->value);
+											if (!s) PUGI_IMPL_THROW_ERROR(status_bad_attribute, a->value);
 
 											// After this line the loop continues from the start;
 											// Whitespaces, / and > are ok, symbols and EOF are wrong,
 											// everything else will be detected
-											if (PUGI__IS_CHARTYPE(*s, ct_start_symbol)) PUGI__THROW_ERROR(status_bad_attribute, s);
+											if (PUGI_IMPL_IS_CHARTYPE(*s, ct_start_symbol)) PUGI_IMPL_THROW_ERROR(status_bad_attribute, s);
 										}
-										else PUGI__THROW_ERROR(status_bad_attribute, s);
+										else PUGI_IMPL_THROW_ERROR(status_bad_attribute, s);
 									}
-									else PUGI__THROW_ERROR(status_bad_attribute, s);
+									else PUGI_IMPL_THROW_ERROR(status_bad_attribute, s);
 								}
 								else if (*s == '/')
 								{
@@ -3339,16 +3378,16 @@ PUGI__NS_BEGIN
 
 									if (*s == '>')
 									{
-										PUGI__POPNODE();
+										PUGI_IMPL_POPNODE();
 										s++;
 										break;
 									}
 									else if (*s == 0 && endch == '>')
 									{
-										PUGI__POPNODE();
+										PUGI_IMPL_POPNODE();
 										break;
 									}
-									else PUGI__THROW_ERROR(status_bad_start_element, s);
+									else PUGI_IMPL_THROW_ERROR(status_bad_start_element, s);
 								}
 								else if (*s == '>')
 								{
@@ -3360,16 +3399,16 @@ PUGI__NS_BEGIN
 								{
 									break;
 								}
-								else PUGI__THROW_ERROR(status_bad_start_element, s);
+								else PUGI_IMPL_THROW_ERROR(status_bad_start_element, s);
 							}
 
 							// !!!
 						}
 						else if (ch == '/') // '<#.../'
 						{
-							if (!PUGI__ENDSWITH(*s, '>')) PUGI__THROW_ERROR(status_bad_start_element, s);
+							if (!PUGI_IMPL_ENDSWITH(*s, '>')) PUGI_IMPL_THROW_ERROR(status_bad_start_element, s);
 
-							PUGI__POPNODE(); // Pop.
+							PUGI_IMPL_POPNODE(); // Pop.
 
 							s += (*s == '>');
 						}
@@ -3378,9 +3417,9 @@ PUGI__NS_BEGIN
 							// we stepped over null terminator, backtrack & handle closing tag
 							--s;
 
-							if (endch != '>') PUGI__THROW_ERROR(status_bad_start_element, s);
+							if (endch != '>') PUGI_IMPL_THROW_ERROR(status_bad_start_element, s);
 						}
-						else PUGI__THROW_ERROR(status_bad_start_element, s);
+						else PUGI_IMPL_THROW_ERROR(status_bad_start_element, s);
 					}
 					else if (*s == '/')
 					{
@@ -3389,30 +3428,30 @@ PUGI__NS_BEGIN
 						mark = s;
 
 						char_t* name = cursor->name;
-						if (!name) PUGI__THROW_ERROR(status_end_element_mismatch, mark);
+						if (!name) PUGI_IMPL_THROW_ERROR(status_end_element_mismatch, mark);
 
-						while (PUGI__IS_CHARTYPE(*s, ct_symbol))
+						while (PUGI_IMPL_IS_CHARTYPE(*s, ct_symbol))
 						{
-							if (*s++ != *name++) PUGI__THROW_ERROR(status_end_element_mismatch, mark);
+							if (*s++ != *name++) PUGI_IMPL_THROW_ERROR(status_end_element_mismatch, mark);
 						}
 
 						if (*name)
 						{
-							if (*s == 0 && name[0] == endch && name[1] == 0) PUGI__THROW_ERROR(status_bad_end_element, s);
-							else PUGI__THROW_ERROR(status_end_element_mismatch, mark);
+							if (*s == 0 && name[0] == endch && name[1] == 0) PUGI_IMPL_THROW_ERROR(status_bad_end_element, s);
+							else PUGI_IMPL_THROW_ERROR(status_end_element_mismatch, mark);
 						}
 
-						PUGI__POPNODE(); // Pop.
+						PUGI_IMPL_POPNODE(); // Pop.
 
-						PUGI__SKIPWS();
+						PUGI_IMPL_SKIPWS();
 
 						if (*s == 0)
 						{
-							if (endch != '>') PUGI__THROW_ERROR(status_bad_end_element, s);
+							if (endch != '>') PUGI_IMPL_THROW_ERROR(status_bad_end_element, s);
 						}
 						else
 						{
-							if (*s != '>') PUGI__THROW_ERROR(status_bad_end_element, s);
+							if (*s != '>') PUGI_IMPL_THROW_ERROR(status_bad_end_element, s);
 							++s;
 						}
 					}
@@ -3422,62 +3461,79 @@ PUGI__NS_BEGIN
 						if (!s) return s;
 
 						assert(cursor);
-						if (PUGI__NODETYPE(cursor) == node_declaration) goto LOC_ATTRIBUTES;
+						if (PUGI_IMPL_NODETYPE(cursor) == node_declaration) goto LOC_ATTRIBUTES;
 					}
 					else if (*s == '!') // '<!...'
 					{
 						s = parse_exclamation(s, cursor, optmsk, endch);
 						if (!s) return s;
 					}
-					else if (*s == 0 && endch == '?') PUGI__THROW_ERROR(status_bad_pi, s);
-					else PUGI__THROW_ERROR(status_unrecognized_tag, s);
+					else if (*s == 0 && endch == '?') PUGI_IMPL_THROW_ERROR(status_bad_pi, s);
+					else PUGI_IMPL_THROW_ERROR(status_unrecognized_tag, s);
 				}
 				else
 				{
 					mark = s; // Save this offset while searching for a terminator.
 
-					PUGI__SKIPWS(); // Eat whitespace if no genuine PCDATA here.
+					PUGI_IMPL_SKIPWS(); // Eat whitespace if no genuine PCDATA here.
 
 					if (*s == '<' || !*s)
 					{
 						// We skipped some whitespace characters because otherwise we would take the tag branch instead of PCDATA one
 						assert(mark != s);
 
-						if (!PUGI__OPTSET(parse_ws_pcdata | parse_ws_pcdata_single) || PUGI__OPTSET(parse_trim_pcdata))
+						if (!PUGI_IMPL_OPTSET(parse_ws_pcdata | parse_ws_pcdata_single) || PUGI_IMPL_OPTSET(parse_trim_pcdata))
 						{
 							continue;
 						}
-						else if (PUGI__OPTSET(parse_ws_pcdata_single))
+						else if (PUGI_IMPL_OPTSET(parse_ws_pcdata_single))
 						{
 							if (s[0] != '<' || s[1] != '/' || cursor->first_child) continue;
 						}
 					}
 
-					if (!PUGI__OPTSET(parse_trim_pcdata))
+					if (!PUGI_IMPL_OPTSET(parse_trim_pcdata))
 						s = mark;
 
-					if (cursor->parent || PUGI__OPTSET(parse_fragment))
+					if (cursor->parent || PUGI_IMPL_OPTSET(parse_fragment))
 					{
-						if (PUGI__OPTSET(parse_embed_pcdata) && cursor->parent && !cursor->first_child && !cursor->value)
+						char_t* parsed_pcdata = s;
+
+						s = strconv_pcdata(s);
+
+						if (PUGI_IMPL_OPTSET(parse_embed_pcdata) && cursor->parent && !cursor->first_child && !cursor->value)
 						{
-							cursor->value = s; // Save the offset.
+							cursor->value = parsed_pcdata; // Save the offset.
+						}
+						else if (PUGI_IMPL_OPTSET(parse_merge_pcdata) && cursor->first_child && PUGI_IMPL_NODETYPE(cursor->first_child->prev_sibling_c) == node_pcdata)
+						{
+							assert(merged_pcdata >= cursor->first_child->prev_sibling_c->value);
+
+							// Catch up to the end of last parsed value; only needed for the first fragment.
+							merged_pcdata += strlength(merged_pcdata);
+
+							size_t length = strlength(parsed_pcdata);
+
+							// Must use memmove instead of memcpy as this move may overlap
+							memmove(merged_pcdata, parsed_pcdata, (length + 1) * sizeof(char_t));
+							merged_pcdata += length;
 						}
 						else
 						{
-							PUGI__PUSHNODE(node_pcdata); // Append a new node on the tree.
+							xml_node_struct* prev_cursor = cursor;
+							PUGI_IMPL_PUSHNODE(node_pcdata); // Append a new node on the tree.
 
-							cursor->value = s; // Save the offset.
+							cursor->value = parsed_pcdata; // Save the offset.
+							merged_pcdata = parsed_pcdata; // Used for parse_merge_pcdata above, cheaper to save unconditionally
 
-							PUGI__POPNODE(); // Pop since this is a standalone.
+							cursor = prev_cursor; // Pop since this is a standalone.
 						}
-
-						s = strconv_pcdata(s);
 
 						if (!*s) break;
 					}
 					else
 					{
-						PUGI__SCANFOR(*s == '<'); // '...<'
+						PUGI_IMPL_SCANFOR(*s == '<'); // '...<'
 						if (!*s) break;
 
 						++s;
@@ -3489,7 +3545,7 @@ PUGI__NS_BEGIN
 			}
 
 			// check that last tag is closed
-			if (cursor != root) PUGI__THROW_ERROR(status_end_element_mismatch, s);
+			if (cursor != root) PUGI_IMPL_THROW_ERROR(status_end_element_mismatch, s);
 
 			return s;
 		}
@@ -3511,7 +3567,7 @@ PUGI__NS_BEGIN
 		{
 			while (node)
 			{
-				if (PUGI__NODETYPE(node) == node_element) return true;
+				if (PUGI_IMPL_NODETYPE(node) == node_element) return true;
 
 				node = node->next_sibling;
 			}
@@ -3523,10 +3579,10 @@ PUGI__NS_BEGIN
 		{
 			// early-out for empty documents
 			if (length == 0)
-				return make_parse_result(PUGI__OPTSET(parse_fragment) ? status_ok : status_no_document_element);
+				return make_parse_result(PUGI_IMPL_OPTSET(parse_fragment) ? status_ok : status_no_document_element);
 
 			// get last child of the root before parsing
-			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : 0;
+			xml_node_struct* last_root_child = root->first_child ? root->first_child->prev_sibling_c + 0 : nullptr;
 
 			// create parser on stack
 			xml_parser parser(static_cast<xml_allocator*>(xmldoc));
@@ -3551,9 +3607,9 @@ PUGI__NS_BEGIN
 					return make_parse_result(status_unrecognized_tag, length - 1);
 
 				// check if there are any element nodes parsed
-				xml_node_struct* first_root_child_parsed = last_root_child ? last_root_child->next_sibling + 0 : root->first_child+ 0;
+				xml_node_struct* first_root_child_parsed = last_root_child ? last_root_child->next_sibling + 0 : root->first_child + 0;
 
-				if (!PUGI__OPTSET(parse_fragment) && !has_element_node_siblings(first_root_child_parsed))
+				if (!PUGI_IMPL_OPTSET(parse_fragment) && !has_element_node_siblings(first_root_child_parsed))
 					return make_parse_result(status_no_document_element, length - 1);
 			}
 			else
@@ -3568,7 +3624,7 @@ PUGI__NS_BEGIN
 	};
 
 	// Output facilities
-	PUGI__FN xml_encoding get_write_native_encoding()
+	PUGI_IMPL_FN xml_encoding get_write_native_encoding()
 	{
 	#ifdef PUGIXML_WCHAR_MODE
 		return get_wchar_encoding();
@@ -3577,7 +3633,7 @@ PUGI__NS_BEGIN
 	#endif
 	}
 
-	PUGI__FN xml_encoding get_write_encoding(xml_encoding encoding)
+	PUGI_IMPL_FN xml_encoding get_write_encoding(xml_encoding encoding)
 	{
 		// replace wchar encoding with utf implementation
 		if (encoding == encoding_wchar) return get_wchar_encoding();
@@ -3595,18 +3651,18 @@ PUGI__NS_BEGIN
 		return encoding_utf8;
 	}
 
-	template <typename D, typename T> PUGI__FN size_t convert_buffer_output_generic(typename T::value_type dest, const char_t* data, size_t length, D, T)
+	template <typename D, typename T> PUGI_IMPL_FN size_t convert_buffer_output_generic(typename T::value_type dest, const char_t* data, size_t length, D, T)
 	{
-		PUGI__STATIC_ASSERT(sizeof(char_t) == sizeof(typename D::type));
+		PUGI_IMPL_STATIC_ASSERT(sizeof(char_t) == sizeof(typename D::type));
 
 		typename T::value_type end = D::process(reinterpret_cast<const typename D::type*>(data), length, dest, T());
 
 		return static_cast<size_t>(end - dest) * sizeof(*dest);
 	}
 
-	template <typename D, typename T> PUGI__FN size_t convert_buffer_output_generic(typename T::value_type dest, const char_t* data, size_t length, D, T, bool opt_swap)
+	template <typename D, typename T> PUGI_IMPL_FN size_t convert_buffer_output_generic(typename T::value_type dest, const char_t* data, size_t length, D, T, bool opt_swap)
 	{
-		PUGI__STATIC_ASSERT(sizeof(char_t) == sizeof(typename D::type));
+		PUGI_IMPL_STATIC_ASSERT(sizeof(char_t) == sizeof(typename D::type));
 
 		typename T::value_type end = D::process(reinterpret_cast<const typename D::type*>(data), length, dest, T());
 
@@ -3620,7 +3676,7 @@ PUGI__NS_BEGIN
 	}
 
 #ifdef PUGIXML_WCHAR_MODE
-	PUGI__FN size_t get_valid_length(const char_t* data, size_t length)
+	PUGI_IMPL_FN size_t get_valid_length(const char_t* data, size_t length)
 	{
 		if (length < 1) return 0;
 
@@ -3628,7 +3684,7 @@ PUGI__NS_BEGIN
 		return (sizeof(wchar_t) == 2 && static_cast<unsigned int>(static_cast<uint16_t>(data[length - 1]) - 0xD800) < 0x400) ? length - 1 : length;
 	}
 
-	PUGI__FN size_t convert_buffer_output(char_t* r_char, uint8_t* r_u8, uint16_t* r_u16, uint32_t* r_u32, const char_t* data, size_t length, xml_encoding encoding)
+	PUGI_IMPL_FN size_t convert_buffer_output(char_t* r_char, uint8_t* r_u8, uint16_t* r_u16, uint32_t* r_u32, const char_t* data, size_t length, xml_encoding encoding)
 	{
 		// only endian-swapping is required
 		if (need_endian_swap_utf(encoding, get_wchar_encoding()))
@@ -3666,7 +3722,7 @@ PUGI__NS_BEGIN
 		return 0;
 	}
 #else
-	PUGI__FN size_t get_valid_length(const char_t* data, size_t length)
+	PUGI_IMPL_FN size_t get_valid_length(const char_t* data, size_t length)
 	{
 		if (length < 5) return 0;
 
@@ -3682,7 +3738,7 @@ PUGI__NS_BEGIN
 		return length;
 	}
 
-	PUGI__FN size_t convert_buffer_output(char_t* /* r_char */, uint8_t* r_u8, uint16_t* r_u16, uint32_t* r_u32, const char_t* data, size_t length, xml_encoding encoding)
+	PUGI_IMPL_FN size_t convert_buffer_output(char_t* /* r_char */, uint8_t* r_u8, uint16_t* r_u16, uint32_t* r_u32, const char_t* data, size_t length, xml_encoding encoding)
 	{
 		if (encoding == encoding_utf16_be || encoding == encoding_utf16_le)
 		{
@@ -3714,7 +3770,7 @@ PUGI__NS_BEGIN
 	public:
 		xml_buffered_writer(xml_writer& writer_, xml_encoding user_encoding): writer(writer_), bufsize(0), encoding(get_write_encoding(user_encoding))
 		{
-			PUGI__STATIC_ASSERT(bufcapacity >= 8);
+			PUGI_IMPL_STATIC_ASSERT(bufcapacity >= 8);
 		}
 
 		size_t flush()
@@ -3920,14 +3976,14 @@ PUGI__NS_BEGIN
 		xml_encoding encoding;
 	};
 
-	PUGI__FN void text_output_escaped(xml_buffered_writer& writer, const char_t* s, chartypex_t type, unsigned int flags)
+	PUGI_IMPL_FN void text_output_escaped(xml_buffered_writer& writer, const char_t* s, chartypex_t type, unsigned int flags)
 	{
 		while (*s)
 		{
 			const char_t* prev = s;
 
 			// While *s is a usual symbol
-			PUGI__SCANWHILE_UNROLL(!PUGI__IS_CHARTYPEX(ss, type));
+			PUGI_IMPL_SCANWHILE_UNROLL(!PUGI_IMPL_IS_CHARTYPEX(ss, type));
 
 			writer.write_buffer(prev, static_cast<size_t>(s - prev));
 
@@ -3972,7 +4028,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN void text_output(xml_buffered_writer& writer, const char_t* s, chartypex_t type, unsigned int flags)
+	PUGI_IMPL_FN void text_output(xml_buffered_writer& writer, const char_t* s, chartypex_t type, unsigned int flags)
 	{
 		if (flags & format_no_escapes)
 			writer.write_string(s);
@@ -3980,7 +4036,7 @@ PUGI__NS_BEGIN
 			text_output_escaped(writer, s, type, flags);
 	}
 
-	PUGI__FN void text_output_cdata(xml_buffered_writer& writer, const char_t* s)
+	PUGI_IMPL_FN void text_output_cdata(xml_buffered_writer& writer, const char_t* s)
 	{
 		do
 		{
@@ -4002,7 +4058,7 @@ PUGI__NS_BEGIN
 		while (*s);
 	}
 
-	PUGI__FN void text_output_indent(xml_buffered_writer& writer, const char_t* indent, size_t indent_length, unsigned int depth)
+	PUGI_IMPL_FN void text_output_indent(xml_buffered_writer& writer, const char_t* indent, size_t indent_length, unsigned int depth)
 	{
 		switch (indent_length)
 		{
@@ -4042,7 +4098,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN void node_output_comment(xml_buffered_writer& writer, const char_t* s)
+	PUGI_IMPL_FN void node_output_comment(xml_buffered_writer& writer, const char_t* s)
 	{
 		writer.write('<', '!', '-', '-');
 
@@ -4067,7 +4123,7 @@ PUGI__NS_BEGIN
 		writer.write('-', '-', '>');
 	}
 
-	PUGI__FN void node_output_pi_value(xml_buffered_writer& writer, const char_t* s)
+	PUGI_IMPL_FN void node_output_pi_value(xml_buffered_writer& writer, const char_t* s)
 	{
 		while (*s)
 		{
@@ -4088,7 +4144,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN void node_output_attributes(xml_buffered_writer& writer, xml_node_struct* node, const char_t* indent, size_t indent_length, unsigned int flags, unsigned int depth)
+	PUGI_IMPL_FN void node_output_attributes(xml_buffered_writer& writer, xml_node_struct* node, const char_t* indent, size_t indent_length, unsigned int flags, unsigned int depth)
 	{
 		const char_t* default_name = PUGIXML_TEXT(":anonymous");
 		const char_t enquotation_char = (flags & format_attribute_single_quote) ? '\'' : '"';
@@ -4116,7 +4172,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN bool node_output_start(xml_buffered_writer& writer, xml_node_struct* node, const char_t* indent, size_t indent_length, unsigned int flags, unsigned int depth)
+	PUGI_IMPL_FN bool node_output_start(xml_buffered_writer& writer, xml_node_struct* node, const char_t* indent, size_t indent_length, unsigned int flags, unsigned int depth)
 	{
 		const char_t* default_name = PUGIXML_TEXT(":anonymous");
 		const char_t* name = node->name ? node->name + 0 : default_name;
@@ -4178,7 +4234,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN void node_output_end(xml_buffered_writer& writer, xml_node_struct* node)
+	PUGI_IMPL_FN void node_output_end(xml_buffered_writer& writer, xml_node_struct* node)
 	{
 		const char_t* default_name = PUGIXML_TEXT(":anonymous");
 		const char_t* name = node->name ? node->name + 0 : default_name;
@@ -4188,11 +4244,11 @@ PUGI__NS_BEGIN
 		writer.write('>');
 	}
 
-	PUGI__FN void node_output_simple(xml_buffered_writer& writer, xml_node_struct* node, unsigned int flags)
+	PUGI_IMPL_FN void node_output_simple(xml_buffered_writer& writer, xml_node_struct* node, unsigned int flags)
 	{
 		const char_t* default_name = PUGIXML_TEXT(":anonymous");
 
-		switch (PUGI__NODETYPE(node))
+		switch (PUGI_IMPL_NODETYPE(node))
 		{
 			case node_pcdata:
 				text_output(writer, node->value ? node->value + 0 : PUGIXML_TEXT(""), ctx_special_pcdata, flags);
@@ -4250,7 +4306,7 @@ PUGI__NS_BEGIN
 		indent_indent = 2
 	};
 
-	PUGI__FN void node_output(xml_buffered_writer& writer, xml_node_struct* root, const char_t* indent, unsigned int flags, unsigned int depth)
+	PUGI_IMPL_FN void node_output(xml_buffered_writer& writer, xml_node_struct* root, const char_t* indent, unsigned int flags, unsigned int depth)
 	{
 		size_t indent_length = ((flags & (format_indent | format_indent_attributes)) && (flags & format_raw) == 0) ? strlength(indent) : 0;
 		unsigned int indent_flags = indent_indent;
@@ -4262,7 +4318,7 @@ PUGI__NS_BEGIN
 			assert(node);
 
 			// begin writing current node
-			if (PUGI__NODETYPE(node) == node_pcdata || PUGI__NODETYPE(node) == node_cdata)
+			if (PUGI_IMPL_NODETYPE(node) == node_pcdata || PUGI_IMPL_NODETYPE(node) == node_cdata)
 			{
 				node_output_simple(writer, node, flags);
 
@@ -4276,7 +4332,7 @@ PUGI__NS_BEGIN
 				if ((indent_flags & indent_indent) && indent_length)
 					text_output_indent(writer, indent, indent_length, depth);
 
-				if (PUGI__NODETYPE(node) == node_element)
+				if (PUGI_IMPL_NODETYPE(node) == node_element)
 				{
 					indent_flags = indent_newline | indent_indent;
 
@@ -4291,7 +4347,7 @@ PUGI__NS_BEGIN
 						continue;
 					}
 				}
-				else if (PUGI__NODETYPE(node) == node_document)
+				else if (PUGI_IMPL_NODETYPE(node) == node_document)
 				{
 					indent_flags = indent_indent;
 
@@ -4321,7 +4377,7 @@ PUGI__NS_BEGIN
 				node = node->parent;
 
 				// write closing node
-				if (PUGI__NODETYPE(node) == node_element)
+				if (PUGI_IMPL_NODETYPE(node) == node_element)
 				{
 					depth--;
 
@@ -4343,11 +4399,11 @@ PUGI__NS_BEGIN
 			writer.write('\n');
 	}
 
-	PUGI__FN bool has_declaration(xml_node_struct* node)
+	PUGI_IMPL_FN bool has_declaration(xml_node_struct* node)
 	{
 		for (xml_node_struct* child = node->first_child; child; child = child->next_sibling)
 		{
-			xml_node_type type = PUGI__NODETYPE(child);
+			xml_node_type type = PUGI_IMPL_NODETYPE(child);
 
 			if (type == node_declaration) return true;
 			if (type == node_element) return false;
@@ -4356,7 +4412,7 @@ PUGI__NS_BEGIN
 		return false;
 	}
 
-	PUGI__FN bool is_attribute_of(xml_attribute_struct* attr, xml_node_struct* node)
+	PUGI_IMPL_FN bool is_attribute_of(xml_attribute_struct* attr, xml_node_struct* node)
 	{
 		for (xml_attribute_struct* a = node->first_attribute; a; a = a->next_attribute)
 			if (a == attr)
@@ -4365,12 +4421,12 @@ PUGI__NS_BEGIN
 		return false;
 	}
 
-	PUGI__FN bool allow_insert_attribute(xml_node_type parent)
+	PUGI_IMPL_FN bool allow_insert_attribute(xml_node_type parent)
 	{
 		return parent == node_element || parent == node_declaration;
 	}
 
-	PUGI__FN bool allow_insert_child(xml_node_type parent, xml_node_type child)
+	PUGI_IMPL_FN bool allow_insert_child(xml_node_type parent, xml_node_type child)
 	{
 		if (parent != node_document && parent != node_element) return false;
 		if (child == node_document || child == node_null) return false;
@@ -4379,7 +4435,7 @@ PUGI__NS_BEGIN
 		return true;
 	}
 
-	PUGI__FN bool allow_move(xml_node parent, xml_node child)
+	PUGI_IMPL_FN bool allow_move(xml_node parent, xml_node child)
 	{
 		// check that child can be a child of parent
 		if (!allow_insert_child(parent.type(), child.type()))
@@ -4404,9 +4460,9 @@ PUGI__NS_BEGIN
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN void node_copy_string(String& dest, Header& header, uintptr_t header_mask, char_t* source, Header& source_header, xml_allocator* alloc)
+	PUGI_IMPL_FN void node_copy_string(String& dest, Header& header, uintptr_t header_mask, char_t* source, Header& source_header, xml_allocator* alloc)
 	{
-		assert(!dest && (header & header_mask) == 0);
+		assert(!dest && (header & header_mask) == 0); // copies are performed into fresh nodes
 
 		if (source)
 		{
@@ -4423,7 +4479,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN void node_copy_contents(xml_node_struct* dn, xml_node_struct* sn, xml_allocator* shared_alloc)
+	PUGI_IMPL_FN void node_copy_contents(xml_node_struct* dn, xml_node_struct* sn, xml_allocator* shared_alloc)
 	{
 		node_copy_string(dn->name, dn->header, xml_memory_page_name_allocated_mask, sn->name, sn->header, shared_alloc);
 		node_copy_string(dn->value, dn->header, xml_memory_page_value_allocated_mask, sn->value, sn->header, shared_alloc);
@@ -4440,10 +4496,10 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN void node_copy_tree(xml_node_struct* dn, xml_node_struct* sn)
+	PUGI_IMPL_FN void node_copy_tree(xml_node_struct* dn, xml_node_struct* sn)
 	{
 		xml_allocator& alloc = get_allocator(dn);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : 0;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sn)) ? &alloc : nullptr;
 
 		node_copy_contents(dn, sn, shared_alloc);
 
@@ -4458,7 +4514,7 @@ PUGI__NS_BEGIN
 			// when a tree is copied into one of the descendants, we need to skip that subtree to avoid an infinite loop
 			if (sit != dn)
 			{
-				xml_node_struct* copy = append_new_node(dit, alloc, PUGI__NODETYPE(sit));
+				xml_node_struct* copy = append_new_node(dit, alloc, PUGI_IMPL_NODETYPE(sit));
 
 				if (copy)
 				{
@@ -4494,10 +4550,10 @@ PUGI__NS_BEGIN
 		assert(!sit || dit == dn->parent);
 	}
 
-	PUGI__FN void node_copy_attribute(xml_attribute_struct* da, xml_attribute_struct* sa)
+	PUGI_IMPL_FN void node_copy_attribute(xml_attribute_struct* da, xml_attribute_struct* sa)
 	{
 		xml_allocator& alloc = get_allocator(da);
-		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : 0;
+		xml_allocator* shared_alloc = (&alloc == &get_allocator(sa)) ? &alloc : nullptr;
 
 		node_copy_string(da->name, da->header, xml_memory_page_name_allocated_mask, sa->name, sa->header, shared_alloc);
 		node_copy_string(da->value, da->header, xml_memory_page_value_allocated_mask, sa->value, sa->header, shared_alloc);
@@ -4505,18 +4561,18 @@ PUGI__NS_BEGIN
 
 	inline bool is_text_node(xml_node_struct* node)
 	{
-		xml_node_type type = PUGI__NODETYPE(node);
+		xml_node_type type = PUGI_IMPL_NODETYPE(node);
 
 		return type == node_pcdata || type == node_cdata;
 	}
 
 	// get value with conversion functions
-	template <typename U> PUGI__FN PUGI__UNSIGNED_OVERFLOW U string_to_integer(const char_t* value, U minv, U maxv)
+	template <typename U> PUGI_IMPL_FN PUGI_IMPL_UNSIGNED_OVERFLOW U string_to_integer(const char_t* value, U minv, U maxv)
 	{
 		U result = 0;
 		const char_t* s = value;
 
-		while (PUGI__IS_CHARTYPE(*s, ct_space))
+		while (PUGI_IMPL_IS_CHARTYPE(*s, ct_space))
 			s++;
 
 		bool negative = (*s == '-');
@@ -4571,7 +4627,7 @@ PUGI__NS_BEGIN
 
 			size_t digits = static_cast<size_t>(s - start);
 
-			PUGI__STATIC_ASSERT(sizeof(U) == 8 || sizeof(U) == 4 || sizeof(U) == 2);
+			PUGI_IMPL_STATIC_ASSERT(sizeof(U) == 8 || sizeof(U) == 4 || sizeof(U) == 2);
 
 			const size_t max_digits10 = sizeof(U) == 8 ? 20 : sizeof(U) == 4 ? 10 : 5;
 			const char_t max_lead = sizeof(U) == 8 ? '1' : sizeof(U) == 4 ? '4' : '6';
@@ -4593,35 +4649,35 @@ PUGI__NS_BEGIN
 			return (overflow || result > maxv) ? maxv : result;
 	}
 
-	PUGI__FN int get_value_int(const char_t* value)
+	PUGI_IMPL_FN int get_value_int(const char_t* value)
 	{
 		return string_to_integer<unsigned int>(value, static_cast<unsigned int>(INT_MIN), INT_MAX);
 	}
 
-	PUGI__FN unsigned int get_value_uint(const char_t* value)
+	PUGI_IMPL_FN unsigned int get_value_uint(const char_t* value)
 	{
 		return string_to_integer<unsigned int>(value, 0, UINT_MAX);
 	}
 
-	PUGI__FN double get_value_double(const char_t* value)
+	PUGI_IMPL_FN double get_value_double(const char_t* value)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
-		return wcstod(value, 0);
+		return wcstod(value, nullptr);
 	#else
-		return strtod(value, 0);
+		return strtod(value, nullptr);
 	#endif
 	}
 
-	PUGI__FN float get_value_float(const char_t* value)
+	PUGI_IMPL_FN float get_value_float(const char_t* value)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
-		return static_cast<float>(wcstod(value, 0));
+		return static_cast<float>(wcstod(value, nullptr));
 	#else
-		return static_cast<float>(strtod(value, 0));
+		return static_cast<float>(strtod(value, nullptr));
 	#endif
 	}
 
-	PUGI__FN bool get_value_bool(const char_t* value)
+	PUGI_IMPL_FN bool get_value_bool(const char_t* value)
 	{
 		// only look at first char
 		char_t first = *value;
@@ -4631,18 +4687,18 @@ PUGI__NS_BEGIN
 	}
 
 #ifdef PUGIXML_HAS_LONG_LONG
-	PUGI__FN long long get_value_llong(const char_t* value)
+	PUGI_IMPL_FN long long get_value_llong(const char_t* value)
 	{
 		return string_to_integer<unsigned long long>(value, static_cast<unsigned long long>(LLONG_MIN), LLONG_MAX);
 	}
 
-	PUGI__FN unsigned long long get_value_ullong(const char_t* value)
+	PUGI_IMPL_FN unsigned long long get_value_ullong(const char_t* value)
 	{
 		return string_to_integer<unsigned long long>(value, 0, ULLONG_MAX);
 	}
 #endif
 
-	template <typename U> PUGI__FN PUGI__UNSIGNED_OVERFLOW char_t* integer_to_string(char_t* begin, char_t* end, U value, bool negative)
+	template <typename U> PUGI_IMPL_FN PUGI_IMPL_UNSIGNED_OVERFLOW char_t* integer_to_string(char_t* begin, char_t* end, U value, bool negative)
 	{
 		char_t* result = end - 1;
 		U rest = negative ? 0 - value : value;
@@ -4664,7 +4720,7 @@ PUGI__NS_BEGIN
 
 	// set value with conversion functions
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_ascii(String& dest, Header& header, uintptr_t header_mask, char* buf)
+	PUGI_IMPL_FN bool set_value_ascii(String& dest, Header& header, uintptr_t header_mask, char* buf)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
 		char_t wbuf[128];
@@ -4680,7 +4736,7 @@ PUGI__NS_BEGIN
 	}
 
 	template <typename U, typename String, typename Header>
-	PUGI__FN bool set_value_integer(String& dest, Header& header, uintptr_t header_mask, U value, bool negative)
+	PUGI_IMPL_FN bool set_value_integer(String& dest, Header& header, uintptr_t header_mask, U value, bool negative)
 	{
 		char_t buf[64];
 		char_t* end = buf + sizeof(buf) / sizeof(buf[0]);
@@ -4690,30 +4746,30 @@ PUGI__NS_BEGIN
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, float value, int precision)
+	PUGI_IMPL_FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, float value, int precision)
 	{
 		char buf[128];
-		PUGI__SNPRINTF(buf, "%.*g", precision, double(value));
+		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, double(value));
 
 		return set_value_ascii(dest, header, header_mask, buf);
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, double value, int precision)
+	PUGI_IMPL_FN bool set_value_convert(String& dest, Header& header, uintptr_t header_mask, double value, int precision)
 	{
 		char buf[128];
-		PUGI__SNPRINTF(buf, "%.*g", precision, value);
+		PUGI_IMPL_SNPRINTF(buf, "%.*g", precision, value);
 
 		return set_value_ascii(dest, header, header_mask, buf);
 	}
 
 	template <typename String, typename Header>
-	PUGI__FN bool set_value_bool(String& dest, Header& header, uintptr_t header_mask, bool value)
+	PUGI_IMPL_FN bool set_value_bool(String& dest, Header& header, uintptr_t header_mask, bool value)
 	{
 		return strcpy_insitu(dest, header, header_mask, value ? PUGIXML_TEXT("true") : PUGIXML_TEXT("false"), value ? 4 : 5);
 	}
 
-	PUGI__FN xml_parse_result load_buffer_impl(xml_document_struct* doc, xml_node_struct* root, void* contents, size_t size, unsigned int options, xml_encoding encoding, bool is_mutable, bool own, char_t** out_buffer)
+	PUGI_IMPL_FN xml_parse_result load_buffer_impl(xml_document_struct* doc, xml_node_struct* root, void* contents, size_t size, unsigned int options, xml_encoding encoding, bool is_mutable, bool own, char_t** out_buffer)
 	{
 		// check input buffer
 		if (!contents && size) return make_parse_result(status_io_error);
@@ -4722,10 +4778,10 @@ PUGI__NS_BEGIN
 		xml_encoding buffer_encoding = impl::get_buffer_encoding(encoding, contents, size);
 
 		// if convert_buffer below throws bad_alloc, we still need to deallocate contents if we own it
-		auto_deleter<void> contents_guard(own ? contents : 0, xml_memory::deallocate);
+		auto_deleter<void> contents_guard(own ? contents : nullptr, xml_memory::deallocate);
 
 		// get private buffer
-		char_t* buffer = 0;
+		char_t* buffer = nullptr;
 		size_t length = 0;
 
 		// coverity[var_deref_model]
@@ -4752,48 +4808,60 @@ PUGI__NS_BEGIN
 		return res;
 	}
 
-	// we need to get length of entire file to load it in memory; the only (relatively) sane way to do it is via seek/tell trick
-	PUGI__FN xml_parse_status get_file_size(FILE* file, size_t& out_result)
+	template <typename T> PUGI_IMPL_FN xml_parse_status convert_file_size(T length, size_t& out_result)
 	{
-	#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
-		// there are 64-bit versions of fseek/ftell, let's use them
-		typedef __int64 length_type;
-
-		_fseeki64(file, 0, SEEK_END);
-		length_type length = _ftelli64(file);
-		_fseeki64(file, 0, SEEK_SET);
-	#elif defined(__MINGW32__) && !defined(__NO_MINGW_LFS) && (!defined(__STRICT_ANSI__) || defined(__MINGW64_VERSION_MAJOR))
-		// there are 64-bit versions of fseek/ftell, let's use them
-		typedef off64_t length_type;
-
-		fseeko64(file, 0, SEEK_END);
-		length_type length = ftello64(file);
-		fseeko64(file, 0, SEEK_SET);
-	#else
-		// if this is a 32-bit OS, long is enough; if this is a unix system, long is 64-bit, which is enough; otherwise we can't do anything anyway.
-		typedef long length_type;
-
-		fseek(file, 0, SEEK_END);
-		length_type length = ftell(file);
-		fseek(file, 0, SEEK_SET);
-	#endif
-
 		// check for I/O errors
 		if (length < 0) return status_io_error;
 
 		// check for overflow
 		size_t result = static_cast<size_t>(length);
 
-		if (static_cast<length_type>(result) != length) return status_out_of_memory;
+		if (static_cast<T>(result) != length) return status_out_of_memory;
 
-		// finalize
 		out_result = result;
-
 		return status_ok;
 	}
 
+	// we need to get length of entire file to load it in memory; the only (relatively) sane way to do it is via seek/tell trick
+	PUGI_IMPL_FN xml_parse_status get_file_size(FILE* file, size_t& out_result)
+	{
+	#if defined(__linux__) || defined(__APPLE__)
+		// this simultaneously retrieves the file size and file mode (to guard against loading non-files)
+		struct stat st;
+		if (fstat(fileno(file), &st) != 0) return status_io_error;
+
+		// anything that's not a regular file doesn't have a coherent length
+		if (!S_ISREG(st.st_mode)) return status_io_error;
+
+		xml_parse_status status = convert_file_size(st.st_size, out_result);
+	#elif defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
+		// there are 64-bit versions of fseek/ftell, let's use them
+		_fseeki64(file, 0, SEEK_END);
+		__int64 length = _ftelli64(file);
+		_fseeki64(file, 0, SEEK_SET);
+
+		xml_parse_status status = convert_file_size(length, out_result);
+	#elif defined(__MINGW32__) && !defined(__NO_MINGW_LFS) && (!defined(__STRICT_ANSI__) || defined(__MINGW64_VERSION_MAJOR))
+		// there are 64-bit versions of fseek/ftell, let's use them
+		fseeko64(file, 0, SEEK_END);
+		off64_t length = ftello64(file);
+		fseeko64(file, 0, SEEK_SET);
+
+		xml_parse_status status = convert_file_size(length, out_result);
+	#else
+		// if this is a 32-bit OS, long is enough; if this is a unix system, long is 64-bit, which is enough; otherwise we can't do anything anyway.
+		fseek(file, 0, SEEK_END);
+		long length = ftell(file);
+		fseek(file, 0, SEEK_SET);
+
+		xml_parse_status status = convert_file_size(length, out_result);
+	#endif
+
+		return status;
+	}
+
 	// This function assumes that buffer has extra sizeof(char_t) writable bytes after size
-	PUGI__FN size_t zero_terminate_buffer(void* buffer, size_t size, xml_encoding encoding)
+	PUGI_IMPL_FN size_t zero_terminate_buffer(void* buffer, size_t size, xml_encoding encoding)
 	{
 		// We only need to zero-terminate if encoding conversion does not do it for us
 	#ifdef PUGIXML_WCHAR_MODE
@@ -4817,7 +4885,7 @@ PUGI__NS_BEGIN
 		return size;
 	}
 
-	PUGI__FN xml_parse_result load_file_impl(xml_document_struct* doc, FILE* file, unsigned int options, xml_encoding encoding, char_t** out_buffer)
+	PUGI_IMPL_FN xml_parse_result load_file_impl(xml_document_struct* doc, FILE* file, unsigned int options, xml_encoding encoding, char_t** out_buffer)
 	{
 		if (!file) return make_parse_result(status_file_not_found);
 
@@ -4846,7 +4914,7 @@ PUGI__NS_BEGIN
 		return load_buffer_impl(doc, doc, contents, zero_terminate_buffer(contents, size, real_encoding), options, real_encoding, true, true, out_buffer);
 	}
 
-	PUGI__FN void close_file(FILE* file)
+	PUGI_IMPL_FN void close_file(FILE* file)
 	{
 		fclose(file);
 	}
@@ -4857,7 +4925,7 @@ PUGI__NS_BEGIN
 		static xml_stream_chunk* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xml_stream_chunk));
-			if (!memory) return 0;
+			if (!memory) return nullptr;
 
 			return new (memory) xml_stream_chunk();
 		}
@@ -4875,7 +4943,7 @@ PUGI__NS_BEGIN
 			}
 		}
 
-		xml_stream_chunk(): next(0), size(0)
+		xml_stream_chunk(): next(nullptr), size(0)
 		{
 		}
 
@@ -4885,13 +4953,13 @@ PUGI__NS_BEGIN
 		T data[xml_memory_page_size / sizeof(T)];
 	};
 
-	template <typename T> PUGI__FN xml_parse_status load_stream_data_noseek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
+	template <typename T> PUGI_IMPL_FN xml_parse_status load_stream_data_noseek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
 	{
-		auto_deleter<xml_stream_chunk<T> > chunks(0, xml_stream_chunk<T>::destroy);
+		auto_deleter<xml_stream_chunk<T> > chunks(nullptr, xml_stream_chunk<T>::destroy);
 
 		// read file to a chunk list
 		size_t total = 0;
-		xml_stream_chunk<T>* last = 0;
+		xml_stream_chunk<T>* last = nullptr;
 
 		while (!stream.eof())
 		{
@@ -4939,7 +5007,7 @@ PUGI__NS_BEGIN
 		return status_ok;
 	}
 
-	template <typename T> PUGI__FN xml_parse_status load_stream_data_seek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
+	template <typename T> PUGI_IMPL_FN xml_parse_status load_stream_data_seek(std::basic_istream<T>& stream, void** out_buffer, size_t* out_size)
 	{
 		// get length of remaining data in stream
 		typename std::basic_istream<T>::pos_type pos = stream.tellg();
@@ -4975,9 +5043,9 @@ PUGI__NS_BEGIN
 		return status_ok;
 	}
 
-	template <typename T> PUGI__FN xml_parse_result load_stream_impl(xml_document_struct* doc, std::basic_istream<T>& stream, unsigned int options, xml_encoding encoding, char_t** out_buffer)
+	template <typename T> PUGI_IMPL_FN xml_parse_result load_stream_impl(xml_document_struct* doc, std::basic_istream<T>& stream, unsigned int options, xml_encoding encoding, char_t** out_buffer)
 	{
-		void* buffer = 0;
+		void* buffer = nullptr;
 		size_t size = 0;
 		xml_parse_status status = status_ok;
 
@@ -5001,18 +5069,26 @@ PUGI__NS_BEGIN
 	}
 #endif
 
-#if defined(PUGI__MSVC_CRT_VERSION) || defined(__BORLANDC__) || (defined(__MINGW32__) && (!defined(__STRICT_ANSI__) || defined(__MINGW64_VERSION_MAJOR)))
-	PUGI__FN FILE* open_file_wide(const wchar_t* path, const wchar_t* mode)
+#if defined(PUGI_IMPL_MSVC_CRT_VERSION) || defined(__BORLANDC__) || (defined(__MINGW32__) && (!defined(__STRICT_ANSI__) || defined(__MINGW64_VERSION_MAJOR)))
+	PUGI_IMPL_FN FILE* open_file_wide(const wchar_t* path, const wchar_t* mode)
 	{
-#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
-		FILE* file = 0;
-		return _wfopen_s(&file, path, mode) == 0 ? file : 0;
+#ifdef PUGIXML_NO_STL
+		// ensure these symbols are consistently referenced to avoid 'unreferenced function' warnings
+		// note that generally these functions are used in STL builds, but PUGIXML_NO_STL leaves the only usage in convert_path_heap
+		(void)&as_utf8_begin;
+		(void)&as_utf8_end;
+		(void)&strlength_wide;
+#endif
+
+#if defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
+		FILE* file = nullptr;
+		return _wfopen_s(&file, path, mode) == 0 ? file : nullptr;
 #else
 		return _wfopen(path, mode);
 #endif
 	}
 #else
-	PUGI__FN char* convert_path_heap(const wchar_t* str)
+	PUGI_IMPL_FN char* convert_path_heap(const wchar_t* str)
 	{
 		assert(str);
 
@@ -5022,7 +5098,7 @@ PUGI__NS_BEGIN
 
 		// allocate resulting string
 		char* result = static_cast<char*>(xml_memory::allocate(size + 1));
-		if (!result) return 0;
+		if (!result) return nullptr;
 
 		// second pass: convert to utf8
 		as_utf8_end(result, size, str, length);
@@ -5033,11 +5109,11 @@ PUGI__NS_BEGIN
 		return result;
 	}
 
-	PUGI__FN FILE* open_file_wide(const wchar_t* path, const wchar_t* mode)
+	PUGI_IMPL_FN FILE* open_file_wide(const wchar_t* path, const wchar_t* mode)
 	{
 		// there is no standard function to open wide paths, so our best bet is to try utf8 path
 		char* path_utf8 = convert_path_heap(path);
-		if (!path_utf8) return 0;
+		if (!path_utf8) return nullptr;
 
 		// convert mode to ASCII (we mirror _wfopen interface)
 		char mode_ascii[4] = {0};
@@ -5053,17 +5129,17 @@ PUGI__NS_BEGIN
 	}
 #endif
 
-	PUGI__FN FILE* open_file(const char* path, const char* mode)
+	PUGI_IMPL_FN FILE* open_file(const char* path, const char* mode)
 	{
-#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
-		FILE* file = 0;
-		return fopen_s(&file, path, mode) == 0 ? file : 0;
+#if defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
+		FILE* file = nullptr;
+		return fopen_s(&file, path, mode) == 0 ? file : nullptr;
 #else
 		return fopen(path, mode);
 #endif
 	}
 
-	PUGI__FN bool save_file_impl(const xml_document& doc, FILE* file, const char_t* indent, unsigned int flags, xml_encoding encoding)
+	PUGI_IMPL_FN bool save_file_impl(const xml_document& doc, FILE* file, const char_t* indent, unsigned int flags, xml_encoding encoding)
 	{
 		if (!file) return false;
 
@@ -5080,7 +5156,7 @@ PUGI__NS_BEGIN
 
 		name_null_sentry(xml_node_struct* node_): node(node_), name(node_->name)
 		{
-			node->name = 0;
+			node->name = nullptr;
 		}
 
 		~name_null_sentry()
@@ -5088,30 +5164,34 @@ PUGI__NS_BEGIN
 			node->name = name;
 		}
 	};
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 namespace pugi
 {
-	PUGI__FN xml_writer_file::xml_writer_file(void* file_): file(file_)
+	PUGI_IMPL_FN xml_writer::~xml_writer()
 	{
 	}
 
-	PUGI__FN void xml_writer_file::write(const void* data, size_t size)
+	PUGI_IMPL_FN xml_writer_file::xml_writer_file(void* file_): file(file_)
+	{
+	}
+
+	PUGI_IMPL_FN void xml_writer_file::write(const void* data, size_t size)
 	{
 		size_t result = fwrite(data, 1, size, static_cast<FILE*>(file));
 		(void)!result; // unfortunately we can't do proper error handling here
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream): narrow_stream(&stream), wide_stream(0)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<char>& stream): narrow_stream(&stream), wide_stream(nullptr)
 	{
 	}
 
-	PUGI__FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream): narrow_stream(0), wide_stream(&stream)
+	PUGI_IMPL_FN xml_writer_stream::xml_writer_stream(std::basic_ostream<wchar_t>& stream): narrow_stream(nullptr), wide_stream(&stream)
 	{
 	}
 
-	PUGI__FN void xml_writer_stream::write(const void* data, size_t size)
+	PUGI_IMPL_FN void xml_writer_stream::write(const void* data, size_t size)
 	{
 		if (narrow_stream)
 		{
@@ -5128,130 +5208,130 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xml_tree_walker::xml_tree_walker(): _depth(0)
+	PUGI_IMPL_FN xml_tree_walker::xml_tree_walker(): _depth(0)
 	{
 	}
 
-	PUGI__FN xml_tree_walker::~xml_tree_walker()
+	PUGI_IMPL_FN xml_tree_walker::~xml_tree_walker()
 	{
 	}
 
-	PUGI__FN int xml_tree_walker::depth() const
+	PUGI_IMPL_FN int xml_tree_walker::depth() const
 	{
 		return _depth;
 	}
 
-	PUGI__FN bool xml_tree_walker::begin(xml_node&)
+	PUGI_IMPL_FN bool xml_tree_walker::begin(xml_node&)
 	{
 		return true;
 	}
 
-	PUGI__FN bool xml_tree_walker::end(xml_node&)
+	PUGI_IMPL_FN bool xml_tree_walker::end(xml_node&)
 	{
 		return true;
 	}
 
-	PUGI__FN xml_attribute::xml_attribute(): _attr(0)
+	PUGI_IMPL_FN xml_attribute::xml_attribute(): _attr(nullptr)
 	{
 	}
 
-	PUGI__FN xml_attribute::xml_attribute(xml_attribute_struct* attr): _attr(attr)
+	PUGI_IMPL_FN xml_attribute::xml_attribute(xml_attribute_struct* attr): _attr(attr)
 	{
 	}
 
-	PUGI__FN static void unspecified_bool_xml_attribute(xml_attribute***)
+	PUGI_IMPL_FN static void unspecified_bool_xml_attribute(xml_attribute***)
 	{
 	}
 
-	PUGI__FN xml_attribute::operator xml_attribute::unspecified_bool_type() const
+	PUGI_IMPL_FN xml_attribute::operator xml_attribute::unspecified_bool_type() const
 	{
-		return _attr ? unspecified_bool_xml_attribute : 0;
+		return _attr ? unspecified_bool_xml_attribute : nullptr;
 	}
 
-	PUGI__FN bool xml_attribute::operator!() const
+	PUGI_IMPL_FN bool xml_attribute::operator!() const
 	{
 		return !_attr;
 	}
 
-	PUGI__FN bool xml_attribute::operator==(const xml_attribute& r) const
+	PUGI_IMPL_FN bool xml_attribute::operator==(const xml_attribute& r) const
 	{
 		return (_attr == r._attr);
 	}
 
-	PUGI__FN bool xml_attribute::operator!=(const xml_attribute& r) const
+	PUGI_IMPL_FN bool xml_attribute::operator!=(const xml_attribute& r) const
 	{
 		return (_attr != r._attr);
 	}
 
-	PUGI__FN bool xml_attribute::operator<(const xml_attribute& r) const
+	PUGI_IMPL_FN bool xml_attribute::operator<(const xml_attribute& r) const
 	{
 		return (_attr < r._attr);
 	}
 
-	PUGI__FN bool xml_attribute::operator>(const xml_attribute& r) const
+	PUGI_IMPL_FN bool xml_attribute::operator>(const xml_attribute& r) const
 	{
 		return (_attr > r._attr);
 	}
 
-	PUGI__FN bool xml_attribute::operator<=(const xml_attribute& r) const
+	PUGI_IMPL_FN bool xml_attribute::operator<=(const xml_attribute& r) const
 	{
 		return (_attr <= r._attr);
 	}
 
-	PUGI__FN bool xml_attribute::operator>=(const xml_attribute& r) const
+	PUGI_IMPL_FN bool xml_attribute::operator>=(const xml_attribute& r) const
 	{
 		return (_attr >= r._attr);
 	}
 
-	PUGI__FN xml_attribute xml_attribute::next_attribute() const
+	PUGI_IMPL_FN xml_attribute xml_attribute::next_attribute() const
 	{
 		if (!_attr) return xml_attribute();
 		return xml_attribute(_attr->next_attribute);
 	}
 
-	PUGI__FN xml_attribute xml_attribute::previous_attribute() const
+	PUGI_IMPL_FN xml_attribute xml_attribute::previous_attribute() const
 	{
 		if (!_attr) return xml_attribute();
 		xml_attribute_struct* prev = _attr->prev_attribute_c;
 		return prev->next_attribute ? xml_attribute(prev) : xml_attribute();
 	}
 
-	PUGI__FN const char_t* xml_attribute::as_string(const char_t* def) const
+	PUGI_IMPL_FN const char_t* xml_attribute::as_string(const char_t* def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
 		return value ? value : def;
 	}
 
-	PUGI__FN int xml_attribute::as_int(int def) const
+	PUGI_IMPL_FN int xml_attribute::as_int(int def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
 		return value ? impl::get_value_int(value) : def;
 	}
 
-	PUGI__FN unsigned int xml_attribute::as_uint(unsigned int def) const
+	PUGI_IMPL_FN unsigned int xml_attribute::as_uint(unsigned int def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
 		return value ? impl::get_value_uint(value) : def;
 	}
 
-	PUGI__FN double xml_attribute::as_double(double def) const
+	PUGI_IMPL_FN double xml_attribute::as_double(double def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
 		return value ? impl::get_value_double(value) : def;
 	}
 
-	PUGI__FN float xml_attribute::as_float(float def) const
+	PUGI_IMPL_FN float xml_attribute::as_float(float def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
 		return value ? impl::get_value_float(value) : def;
 	}
 
-	PUGI__FN bool xml_attribute::as_bool(bool def) const
+	PUGI_IMPL_FN bool xml_attribute::as_bool(bool def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
@@ -5259,14 +5339,14 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_LONG_LONG
-	PUGI__FN long long xml_attribute::as_llong(long long def) const
+	PUGI_IMPL_FN long long xml_attribute::as_llong(long long def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
 		return value ? impl::get_value_llong(value) : def;
 	}
 
-	PUGI__FN unsigned long long xml_attribute::as_ullong(unsigned long long def) const
+	PUGI_IMPL_FN unsigned long long xml_attribute::as_ullong(unsigned long long def) const
 	{
 		if (!_attr) return def;
 		const char_t* value = _attr->value;
@@ -5274,175 +5354,208 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_attribute::empty() const
+	PUGI_IMPL_FN bool xml_attribute::empty() const
 	{
 		return !_attr;
 	}
 
-	PUGI__FN const char_t* xml_attribute::name() const
+	PUGI_IMPL_FN const char_t* xml_attribute::name() const
 	{
 		if (!_attr) return PUGIXML_TEXT("");
 		const char_t* name = _attr->name;
 		return name ? name : PUGIXML_TEXT("");
 	}
 
-	PUGI__FN const char_t* xml_attribute::value() const
+	PUGI_IMPL_FN const char_t* xml_attribute::value() const
 	{
 		if (!_attr) return PUGIXML_TEXT("");
 		const char_t* value = _attr->value;
 		return value ? value : PUGIXML_TEXT("");
 	}
 
-	PUGI__FN size_t xml_attribute::hash_value() const
+	PUGI_IMPL_FN size_t xml_attribute::hash_value() const
 	{
-		return static_cast<size_t>(reinterpret_cast<uintptr_t>(_attr) / sizeof(xml_attribute_struct));
+		return reinterpret_cast<uintptr_t>(_attr) / sizeof(xml_attribute_struct);
 	}
 
-	PUGI__FN xml_attribute_struct* xml_attribute::internal_object() const
+	PUGI_IMPL_FN xml_attribute_struct* xml_attribute::internal_object() const
 	{
 		return _attr;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(const char_t* rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(const char_t* rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(int rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(int rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(unsigned int rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(unsigned int rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(long rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(long rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(unsigned long rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(unsigned long rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(double rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(double rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(float rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(float rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute::operator=(bool rhs)
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(bool rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 
-#ifdef PUGIXML_HAS_LONG_LONG
-	PUGI__FN xml_attribute& xml_attribute::operator=(long long rhs)
-	{
-		set_value(rhs);
-		return *this;
-	}
-
-	PUGI__FN xml_attribute& xml_attribute::operator=(unsigned long long rhs)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(string_view_t rhs)
 	{
 		set_value(rhs);
 		return *this;
 	}
 #endif
 
-	PUGI__FN bool xml_attribute::set_name(const char_t* rhs)
+#ifdef PUGIXML_HAS_LONG_LONG
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(long long rhs)
+	{
+		set_value(rhs);
+		return *this;
+	}
+
+	PUGI_IMPL_FN xml_attribute& xml_attribute::operator=(unsigned long long rhs)
+	{
+		set_value(rhs);
+		return *this;
+	}
+#endif
+
+	PUGI_IMPL_FN bool xml_attribute::set_name(const char_t* rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
 	}
 
-	PUGI__FN bool xml_attribute::set_value(const char_t* rhs, size_t sz)
+	PUGI_IMPL_FN bool xml_attribute::set_name(const char_t* rhs, size_t size)
 	{
 		if (!_attr) return false;
 
-		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, sz);
+		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs, size);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(const char_t* rhs)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_attribute::set_name(string_view_t rhs)
+	{
+		if (!_attr) return false;
+
+		return impl::strcpy_insitu(_attr->name, _attr->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.size());
+	}
+#endif
+
+	PUGI_IMPL_FN bool xml_attribute::set_value(const char_t* rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs));
 	}
 
-	PUGI__FN bool xml_attribute::set_value(int rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(const char_t* rhs, size_t size)
+	{
+		if (!_attr) return false;
+
+		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, size);
+	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_attribute::set_value(string_view_t rhs)
+	{
+		if (!_attr) return false;
+
+		return impl::strcpy_insitu(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.size());
+	}
+#endif
+
+	PUGI_IMPL_FN bool xml_attribute::set_value(int rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_integer<unsigned int>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(unsigned int rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(unsigned int rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_integer<unsigned int>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(long rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(long rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_integer<unsigned long>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(unsigned long rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(unsigned long rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_integer<unsigned long>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, false);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(double rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(double rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, default_double_precision);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(double rhs, int precision)
+	PUGI_IMPL_FN bool xml_attribute::set_value(double rhs, int precision)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, precision);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(float rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(float rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, default_float_precision);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(float rhs, int precision)
+	PUGI_IMPL_FN bool xml_attribute::set_value(float rhs, int precision)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_convert(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, precision);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(bool rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(bool rhs)
 	{
 		if (!_attr) return false;
 
@@ -5450,14 +5563,14 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_LONG_LONG
-	PUGI__FN bool xml_attribute::set_value(long long rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(long long rhs)
 	{
 		if (!_attr) return false;
 
 		return impl::set_value_integer<unsigned long long>(_attr->value, _attr->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0);
 	}
 
-	PUGI__FN bool xml_attribute::set_value(unsigned long long rhs)
+	PUGI_IMPL_FN bool xml_attribute::set_value(unsigned long long rhs)
 	{
 		if (!_attr) return false;
 
@@ -5466,129 +5579,129 @@ namespace pugi
 #endif
 
 #ifdef __BORLANDC__
-	PUGI__FN bool operator&&(const xml_attribute& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator&&(const xml_attribute& lhs, bool rhs)
 	{
 		return (bool)lhs && rhs;
 	}
 
-	PUGI__FN bool operator||(const xml_attribute& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator||(const xml_attribute& lhs, bool rhs)
 	{
 		return (bool)lhs || rhs;
 	}
 #endif
 
-	PUGI__FN xml_node::xml_node(): _root(0)
+	PUGI_IMPL_FN xml_node::xml_node(): _root(nullptr)
 	{
 	}
 
-	PUGI__FN xml_node::xml_node(xml_node_struct* p): _root(p)
+	PUGI_IMPL_FN xml_node::xml_node(xml_node_struct* p): _root(p)
 	{
 	}
 
-	PUGI__FN static void unspecified_bool_xml_node(xml_node***)
+	PUGI_IMPL_FN static void unspecified_bool_xml_node(xml_node***)
 	{
 	}
 
-	PUGI__FN xml_node::operator xml_node::unspecified_bool_type() const
+	PUGI_IMPL_FN xml_node::operator xml_node::unspecified_bool_type() const
 	{
-		return _root ? unspecified_bool_xml_node : 0;
+		return _root ? unspecified_bool_xml_node : nullptr;
 	}
 
-	PUGI__FN bool xml_node::operator!() const
+	PUGI_IMPL_FN bool xml_node::operator!() const
 	{
 		return !_root;
 	}
 
-	PUGI__FN xml_node::iterator xml_node::begin() const
+	PUGI_IMPL_FN xml_node::iterator xml_node::begin() const
 	{
-		return iterator(_root ? _root->first_child + 0 : 0, _root);
+		return iterator(_root ? _root->first_child + 0 : nullptr, _root);
 	}
 
-	PUGI__FN xml_node::iterator xml_node::end() const
+	PUGI_IMPL_FN xml_node::iterator xml_node::end() const
 	{
-		return iterator(0, _root);
+		return iterator(nullptr, _root);
 	}
 
-	PUGI__FN xml_node::attribute_iterator xml_node::attributes_begin() const
+	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_begin() const
 	{
-		return attribute_iterator(_root ? _root->first_attribute + 0 : 0, _root);
+		return attribute_iterator(_root ? _root->first_attribute + 0 : nullptr, _root);
 	}
 
-	PUGI__FN xml_node::attribute_iterator xml_node::attributes_end() const
+	PUGI_IMPL_FN xml_node::attribute_iterator xml_node::attributes_end() const
 	{
-		return attribute_iterator(0, _root);
+		return attribute_iterator(nullptr, _root);
 	}
 
-	PUGI__FN xml_object_range<xml_node_iterator> xml_node::children() const
+	PUGI_IMPL_FN xml_object_range<xml_node_iterator> xml_node::children() const
 	{
 		return xml_object_range<xml_node_iterator>(begin(), end());
 	}
 
-	PUGI__FN xml_object_range<xml_named_node_iterator> xml_node::children(const char_t* name_) const
+	PUGI_IMPL_FN xml_object_range<xml_named_node_iterator> xml_node::children(const char_t* name_) const
 	{
-		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(0, _root, name_));
+		return xml_object_range<xml_named_node_iterator>(xml_named_node_iterator(child(name_)._root, _root, name_), xml_named_node_iterator(nullptr, _root, name_));
 	}
 
-	PUGI__FN xml_object_range<xml_attribute_iterator> xml_node::attributes() const
+	PUGI_IMPL_FN xml_object_range<xml_attribute_iterator> xml_node::attributes() const
 	{
 		return xml_object_range<xml_attribute_iterator>(attributes_begin(), attributes_end());
 	}
 
-	PUGI__FN bool xml_node::operator==(const xml_node& r) const
+	PUGI_IMPL_FN bool xml_node::operator==(const xml_node& r) const
 	{
 		return (_root == r._root);
 	}
 
-	PUGI__FN bool xml_node::operator!=(const xml_node& r) const
+	PUGI_IMPL_FN bool xml_node::operator!=(const xml_node& r) const
 	{
 		return (_root != r._root);
 	}
 
-	PUGI__FN bool xml_node::operator<(const xml_node& r) const
+	PUGI_IMPL_FN bool xml_node::operator<(const xml_node& r) const
 	{
 		return (_root < r._root);
 	}
 
-	PUGI__FN bool xml_node::operator>(const xml_node& r) const
+	PUGI_IMPL_FN bool xml_node::operator>(const xml_node& r) const
 	{
 		return (_root > r._root);
 	}
 
-	PUGI__FN bool xml_node::operator<=(const xml_node& r) const
+	PUGI_IMPL_FN bool xml_node::operator<=(const xml_node& r) const
 	{
 		return (_root <= r._root);
 	}
 
-	PUGI__FN bool xml_node::operator>=(const xml_node& r) const
+	PUGI_IMPL_FN bool xml_node::operator>=(const xml_node& r) const
 	{
 		return (_root >= r._root);
 	}
 
-	PUGI__FN bool xml_node::empty() const
+	PUGI_IMPL_FN bool xml_node::empty() const
 	{
 		return !_root;
 	}
 
-	PUGI__FN const char_t* xml_node::name() const
+	PUGI_IMPL_FN const char_t* xml_node::name() const
 	{
 		if (!_root) return PUGIXML_TEXT("");
 		const char_t* name = _root->name;
 		return name ? name : PUGIXML_TEXT("");
 	}
 
-	PUGI__FN xml_node_type xml_node::type() const
+	PUGI_IMPL_FN xml_node_type xml_node::type() const
 	{
-		return _root ? PUGI__NODETYPE(_root) : node_null;
+		return _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
 	}
 
-	PUGI__FN const char_t* xml_node::value() const
+	PUGI_IMPL_FN const char_t* xml_node::value() const
 	{
 		if (!_root) return PUGIXML_TEXT("");
 		const char_t* value = _root->value;
 		return value ? value : PUGIXML_TEXT("");
 	}
 
-	PUGI__FN xml_node xml_node::child(const char_t* name_) const
+	PUGI_IMPL_FN xml_node xml_node::child(const char_t* name_) const
 	{
 		if (!_root) return xml_node();
 
@@ -5602,7 +5715,7 @@ namespace pugi
 		return xml_node();
 	}
 
-	PUGI__FN xml_attribute xml_node::attribute(const char_t* name_) const
+	PUGI_IMPL_FN xml_attribute xml_node::attribute(const char_t* name_) const
 	{
 		if (!_root) return xml_attribute();
 
@@ -5616,7 +5729,7 @@ namespace pugi
 		return xml_attribute();
 	}
 
-	PUGI__FN xml_node xml_node::next_sibling(const char_t* name_) const
+	PUGI_IMPL_FN xml_node xml_node::next_sibling(const char_t* name_) const
 	{
 		if (!_root) return xml_node();
 
@@ -5630,12 +5743,12 @@ namespace pugi
 		return xml_node();
 	}
 
-	PUGI__FN xml_node xml_node::next_sibling() const
+	PUGI_IMPL_FN xml_node xml_node::next_sibling() const
 	{
 		return _root ? xml_node(_root->next_sibling) : xml_node();
 	}
 
-	PUGI__FN xml_node xml_node::previous_sibling(const char_t* name_) const
+	PUGI_IMPL_FN xml_node xml_node::previous_sibling(const char_t* name_) const
 	{
 		if (!_root) return xml_node();
 
@@ -5649,7 +5762,65 @@ namespace pugi
 		return xml_node();
 	}
 
-	PUGI__FN xml_attribute xml_node::attribute(const char_t* name_, xml_attribute& hint_) const
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_node xml_node::child(string_view_t name_) const
+	{
+		if (!_root) return xml_node();
+
+		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_node(i);
+		}
+
+		return xml_node();
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::attribute(string_view_t name_) const
+	{
+		if (!_root) return xml_attribute();
+
+		for (xml_attribute_struct* i = _root->first_attribute; i; i = i->next_attribute)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_attribute(i);
+		}
+
+		return xml_attribute();
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::next_sibling(string_view_t name_) const
+	{
+		if (!_root) return xml_node();
+
+		for (xml_node_struct* i = _root->next_sibling; i; i = i->next_sibling)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_node(i);
+		}
+
+		return xml_node();
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::previous_sibling(string_view_t name_) const
+	{
+		if (!_root) return xml_node();
+
+		for (xml_node_struct* i = _root->prev_sibling_c; i->next_sibling; i = i->prev_sibling_c)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+				return xml_node(i);
+		}
+
+		return xml_node();
+	}
+#endif
+
+	PUGI_IMPL_FN xml_attribute xml_node::attribute(const char_t* name_, xml_attribute& hint_) const
 	{
 		xml_attribute_struct* hint = hint_._attr;
 
@@ -5688,34 +5859,75 @@ namespace pugi
 		return xml_attribute();
 	}
 
-	PUGI__FN xml_node xml_node::previous_sibling() const
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_attribute xml_node::attribute(string_view_t name_, xml_attribute& hint_) const
+	{
+		xml_attribute_struct* hint = hint_._attr;
+
+		// if hint is not an attribute of node, behavior is not defined
+		assert(!hint || (_root && impl::is_attribute_of(hint, _root)));
+
+		if (!_root) return xml_attribute();
+
+		// optimistically search from hint up until the end
+		for (xml_attribute_struct* i = hint; i; i = i->next_attribute)
+		{
+			const char_t* iname = i->name;
+			if (iname && impl::stringview_equal(name_, iname))
+			{
+				// update hint to maximize efficiency of searching for consecutive attributes
+				hint_._attr = i->next_attribute;
+
+				return xml_attribute(i);
+			}
+		}
+
+		// wrap around and search from the first attribute until the hint
+		// 'j' null pointer check is technically redundant, but it prevents a crash in case the assertion above fails
+		for (xml_attribute_struct* j = _root->first_attribute; j && j != hint; j = j->next_attribute)
+		{
+			const char_t* jname = j->name;
+			if (jname && impl::stringview_equal(name_, jname))
+			{
+				// update hint to maximize efficiency of searching for consecutive attributes
+				hint_._attr = j->next_attribute;
+
+				return xml_attribute(j);
+			}
+		}
+
+		return xml_attribute();
+	}
+#endif
+
+	PUGI_IMPL_FN xml_node xml_node::previous_sibling() const
 	{
 		if (!_root) return xml_node();
 		xml_node_struct* prev = _root->prev_sibling_c;
 		return prev->next_sibling ? xml_node(prev) : xml_node();
 	}
 
-	PUGI__FN xml_node xml_node::parent() const
+	PUGI_IMPL_FN xml_node xml_node::parent() const
 	{
 		return _root ? xml_node(_root->parent) : xml_node();
 	}
 
-	PUGI__FN xml_node xml_node::root() const
+	PUGI_IMPL_FN xml_node xml_node::root() const
 	{
 		return _root ? xml_node(&impl::get_document(_root)) : xml_node();
 	}
 
-	PUGI__FN xml_text xml_node::text() const
+	PUGI_IMPL_FN xml_text xml_node::text() const
 	{
 		return xml_text(_root);
 	}
 
-	PUGI__FN const char_t* xml_node::child_value() const
+	PUGI_IMPL_FN const char_t* xml_node::child_value() const
 	{
 		if (!_root) return PUGIXML_TEXT("");
 
 		// element nodes can have value if parse_embed_pcdata was used
-		if (PUGI__NODETYPE(_root) == node_element && _root->value)
+		if (PUGI_IMPL_NODETYPE(_root) == node_element && _root->value)
 			return _root->value;
 
 		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
@@ -5728,40 +5940,40 @@ namespace pugi
 		return PUGIXML_TEXT("");
 	}
 
-	PUGI__FN const char_t* xml_node::child_value(const char_t* name_) const
+	PUGI_IMPL_FN const char_t* xml_node::child_value(const char_t* name_) const
 	{
 		return child(name_).child_value();
 	}
 
-	PUGI__FN xml_attribute xml_node::first_attribute() const
+	PUGI_IMPL_FN xml_attribute xml_node::first_attribute() const
 	{
 		if (!_root) return xml_attribute();
 		return xml_attribute(_root->first_attribute);
 	}
 
-	PUGI__FN xml_attribute xml_node::last_attribute() const
+	PUGI_IMPL_FN xml_attribute xml_node::last_attribute() const
 	{
 		if (!_root) return xml_attribute();
 		xml_attribute_struct* first = _root->first_attribute;
 		return first ? xml_attribute(first->prev_attribute_c) : xml_attribute();
 	}
 
-	PUGI__FN xml_node xml_node::first_child() const
+	PUGI_IMPL_FN xml_node xml_node::first_child() const
 	{
 		if (!_root) return xml_node();
 		return xml_node(_root->first_child);
 	}
 
-	PUGI__FN xml_node xml_node::last_child() const
+	PUGI_IMPL_FN xml_node xml_node::last_child() const
 	{
 		if (!_root) return xml_node();
 		xml_node_struct* first = _root->first_child;
 		return first ? xml_node(first->prev_sibling_c) : xml_node();
 	}
 
-	PUGI__FN bool xml_node::set_name(const char_t* rhs)
+	PUGI_IMPL_FN bool xml_node::set_name(const char_t* rhs)
 	{
-		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
+		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
 
 		if (type_ != node_element && type_ != node_pi && type_ != node_declaration)
 			return false;
@@ -5769,19 +5981,31 @@ namespace pugi
 		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs, impl::strlength(rhs));
 	}
 
-	PUGI__FN bool xml_node::set_value(const char_t* rhs, size_t sz)
+	PUGI_IMPL_FN bool xml_node::set_name(const char_t* rhs, size_t size)
 	{
-		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
+		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
 
-		if (type_ != node_pcdata && type_ != node_cdata && type_ != node_comment && type_ != node_pi && type_ != node_doctype)
+		if (type_ != node_element && type_ != node_pi && type_ != node_declaration)
 			return false;
 
-		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs, sz);
+		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs, size);
 	}
 
-	PUGI__FN bool xml_node::set_value(const char_t* rhs)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::set_name(string_view_t rhs)
 	{
-		xml_node_type type_ = _root ? PUGI__NODETYPE(_root) : node_null;
+		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
+
+		if (type_ != node_element && type_ != node_pi && type_ != node_declaration)
+			return false;
+
+		return impl::strcpy_insitu(_root->name, _root->header, impl::xml_memory_page_name_allocated_mask, rhs.data(), rhs.size());
+	}
+#endif
+
+	PUGI_IMPL_FN bool xml_node::set_value(const char_t* rhs)
+	{
+		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
 
 		if (type_ != node_pcdata && type_ != node_cdata && type_ != node_comment && type_ != node_pi && type_ != node_doctype)
 			return false;
@@ -5789,7 +6013,29 @@ namespace pugi
 		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs));
 	}
 
-	PUGI__FN xml_attribute xml_node::append_attribute(const char_t* name_)
+	PUGI_IMPL_FN bool xml_node::set_value(const char_t* rhs, size_t size)
+	{
+		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
+
+		if (type_ != node_pcdata && type_ != node_cdata && type_ != node_comment && type_ != node_pi && type_ != node_doctype)
+			return false;
+
+		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs, size);
+	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::set_value(string_view_t rhs)
+	{
+		xml_node_type type_ = _root ? PUGI_IMPL_NODETYPE(_root) : node_null;
+
+		if (type_ != node_pcdata && type_ != node_cdata && type_ != node_comment && type_ != node_pi && type_ != node_doctype)
+			return false;
+
+		return impl::strcpy_insitu(_root->value, _root->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.size());
+	}
+#endif
+
+	PUGI_IMPL_FN xml_attribute xml_node::append_attribute(const char_t* name_)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5806,7 +6052,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::prepend_attribute(const char_t* name_)
+	PUGI_IMPL_FN xml_attribute xml_node::prepend_attribute(const char_t* name_)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 
@@ -5823,7 +6069,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_after(const char_t* name_, const xml_attribute& attr)
+	PUGI_IMPL_FN xml_attribute xml_node::insert_attribute_after(const char_t* name_, const xml_attribute& attr)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5841,7 +6087,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_attribute_before(const char_t* name_, const xml_attribute& attr)
+	PUGI_IMPL_FN xml_attribute xml_node::insert_attribute_before(const char_t* name_, const xml_attribute& attr)
 	{
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
 		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
@@ -5859,7 +6105,79 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::append_copy(const xml_attribute& proto)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_attribute xml_node::append_attribute(string_view_t name_)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::append_attribute(a._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::prepend_attribute(string_view_t name_)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::prepend_attribute(a._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::insert_attribute_after(string_view_t name_, const xml_attribute& attr)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::insert_attribute_after(a._attr, attr._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+
+	PUGI_IMPL_FN xml_attribute xml_node::insert_attribute_before(string_view_t name_, const xml_attribute& attr)
+	{
+		if (!impl::allow_insert_attribute(type())) return xml_attribute();
+		if (!attr || !impl::is_attribute_of(attr._attr, _root)) return xml_attribute();
+
+		impl::xml_allocator& alloc = impl::get_allocator(_root);
+		if (!alloc.reserve()) return xml_attribute();
+
+		xml_attribute a(impl::allocate_attribute(alloc));
+		if (!a) return xml_attribute();
+
+		impl::insert_attribute_before(a._attr, attr._attr, _root);
+
+		a.set_name(name_);
+
+		return a;
+	}
+#endif
+
+	PUGI_IMPL_FN xml_attribute xml_node::append_copy(const xml_attribute& proto)
 	{
 		if (!proto) return xml_attribute();
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
@@ -5876,7 +6194,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::prepend_copy(const xml_attribute& proto)
+	PUGI_IMPL_FN xml_attribute xml_node::prepend_copy(const xml_attribute& proto)
 	{
 		if (!proto) return xml_attribute();
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
@@ -5893,7 +6211,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_copy_after(const xml_attribute& proto, const xml_attribute& attr)
+	PUGI_IMPL_FN xml_attribute xml_node::insert_copy_after(const xml_attribute& proto, const xml_attribute& attr)
 	{
 		if (!proto) return xml_attribute();
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
@@ -5911,7 +6229,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_attribute xml_node::insert_copy_before(const xml_attribute& proto, const xml_attribute& attr)
+	PUGI_IMPL_FN xml_attribute xml_node::insert_copy_before(const xml_attribute& proto, const xml_attribute& attr)
 	{
 		if (!proto) return xml_attribute();
 		if (!impl::allow_insert_attribute(type())) return xml_attribute();
@@ -5929,7 +6247,7 @@ namespace pugi
 		return a;
 	}
 
-	PUGI__FN xml_node xml_node::append_child(xml_node_type type_)
+	PUGI_IMPL_FN xml_node xml_node::append_child(xml_node_type type_)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
 
@@ -5946,7 +6264,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::prepend_child(xml_node_type type_)
+	PUGI_IMPL_FN xml_node xml_node::prepend_child(xml_node_type type_)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
 
@@ -5963,7 +6281,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_before(xml_node_type type_, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_child_before(xml_node_type type_, const xml_node& node)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
 		if (!node._root || node._root->parent != _root) return xml_node();
@@ -5981,7 +6299,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_after(xml_node_type type_, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_child_after(xml_node_type type_, const xml_node& node)
 	{
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
 		if (!node._root || node._root->parent != _root) return xml_node();
@@ -5999,7 +6317,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::append_child(const char_t* name_)
+	PUGI_IMPL_FN xml_node xml_node::append_child(const char_t* name_)
 	{
 		xml_node result = append_child(node_element);
 
@@ -6008,7 +6326,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::prepend_child(const char_t* name_)
+	PUGI_IMPL_FN xml_node xml_node::prepend_child(const char_t* name_)
 	{
 		xml_node result = prepend_child(node_element);
 
@@ -6017,7 +6335,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_after(const char_t* name_, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_child_after(const char_t* name_, const xml_node& node)
 	{
 		xml_node result = insert_child_after(node_element, node);
 
@@ -6026,7 +6344,7 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::insert_child_before(const char_t* name_, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_child_before(const char_t* name_, const xml_node& node)
 	{
 		xml_node result = insert_child_before(node_element, node);
 
@@ -6035,7 +6353,45 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN xml_node xml_node::append_copy(const xml_node& proto)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_node xml_node::append_child(string_view_t name_)
+	{
+		xml_node result = append_child(node_element);
+
+		result.set_name(name_);
+
+		return result;
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::prepend_child(string_view_t name_)
+	{
+		xml_node result = prepend_child(node_element);
+
+		result.set_name(name_);
+
+		return result;
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::insert_child_after(string_view_t name_, const xml_node& node)
+	{
+		xml_node result = insert_child_after(node_element, node);
+
+		result.set_name(name_);
+
+		return result;
+	}
+
+	PUGI_IMPL_FN xml_node xml_node::insert_child_before(string_view_t name_, const xml_node& node)
+	{
+		xml_node result = insert_child_before(node_element, node);
+
+		result.set_name(name_);
+
+		return result;
+	}
+#endif
+
+	PUGI_IMPL_FN xml_node xml_node::append_copy(const xml_node& proto)
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
@@ -6052,7 +6408,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::prepend_copy(const xml_node& proto)
+	PUGI_IMPL_FN xml_node xml_node::prepend_copy(const xml_node& proto)
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
@@ -6069,7 +6425,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::insert_copy_after(const xml_node& proto, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_copy_after(const xml_node& proto, const xml_node& node)
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
@@ -6087,7 +6443,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::insert_copy_before(const xml_node& proto, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_copy_before(const xml_node& proto, const xml_node& node)
 	{
 		xml_node_type type_ = proto.type();
 		if (!impl::allow_insert_child(type(), type_)) return xml_node();
@@ -6105,7 +6461,7 @@ namespace pugi
 		return n;
 	}
 
-	PUGI__FN xml_node xml_node::append_move(const xml_node& moved)
+	PUGI_IMPL_FN xml_node xml_node::append_move(const xml_node& moved)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
 
@@ -6121,7 +6477,7 @@ namespace pugi
 		return moved;
 	}
 
-	PUGI__FN xml_node xml_node::prepend_move(const xml_node& moved)
+	PUGI_IMPL_FN xml_node xml_node::prepend_move(const xml_node& moved)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
 
@@ -6137,7 +6493,7 @@ namespace pugi
 		return moved;
 	}
 
-	PUGI__FN xml_node xml_node::insert_move_after(const xml_node& moved, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_move_after(const xml_node& moved, const xml_node& node)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
 		if (!node._root || node._root->parent != _root) return xml_node();
@@ -6155,7 +6511,7 @@ namespace pugi
 		return moved;
 	}
 
-	PUGI__FN xml_node xml_node::insert_move_before(const xml_node& moved, const xml_node& node)
+	PUGI_IMPL_FN xml_node xml_node::insert_move_before(const xml_node& moved, const xml_node& node)
 	{
 		if (!impl::allow_move(*this, moved)) return xml_node();
 		if (!node._root || node._root->parent != _root) return xml_node();
@@ -6173,12 +6529,19 @@ namespace pugi
 		return moved;
 	}
 
-	PUGI__FN bool xml_node::remove_attribute(const char_t* name_)
+	PUGI_IMPL_FN bool xml_node::remove_attribute(const char_t* name_)
 	{
 		return remove_attribute(attribute(name_));
 	}
 
-	PUGI__FN bool xml_node::remove_attribute(const xml_attribute& a)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::remove_attribute(string_view_t name_)
+	{
+		return remove_attribute(attribute(name_));
+	}
+#endif
+
+	PUGI_IMPL_FN bool xml_node::remove_attribute(const xml_attribute& a)
 	{
 		if (!_root || !a._attr) return false;
 		if (!impl::is_attribute_of(a._attr, _root)) return false;
@@ -6192,7 +6555,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN bool xml_node::remove_attributes()
+	PUGI_IMPL_FN bool xml_node::remove_attributes()
 	{
 		if (!_root) return false;
 
@@ -6208,17 +6571,24 @@ namespace pugi
 			attr = next;
 		}
 
-		_root->first_attribute = 0;
+		_root->first_attribute = nullptr;
 
 		return true;
 	}
 
-	PUGI__FN bool xml_node::remove_child(const char_t* name_)
+	PUGI_IMPL_FN bool xml_node::remove_child(const char_t* name_)
 	{
 		return remove_child(child(name_));
 	}
 
-	PUGI__FN bool xml_node::remove_child(const xml_node& n)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_node::remove_child(string_view_t name_)
+	{
+		return remove_child(child(name_));
+	}
+#endif
+
+	PUGI_IMPL_FN bool xml_node::remove_child(const xml_node& n)
 	{
 		if (!_root || !n._root || n._root->parent != _root) return false;
 
@@ -6231,7 +6601,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN bool xml_node::remove_children()
+	PUGI_IMPL_FN bool xml_node::remove_children()
 	{
 		if (!_root) return false;
 
@@ -6247,15 +6617,18 @@ namespace pugi
 			cur = next;
 		}
 
-		_root->first_child = 0;
+		_root->first_child = nullptr;
 
 		return true;
 	}
 
-	PUGI__FN xml_parse_result xml_node::append_buffer(const void* contents, size_t size, unsigned int options, xml_encoding encoding)
+	PUGI_IMPL_FN xml_parse_result xml_node::append_buffer(const void* contents, size_t size, unsigned int options, xml_encoding encoding)
 	{
 		// append_buffer is only valid for elements/documents
 		if (!impl::allow_insert_child(type(), node_element)) return impl::make_parse_result(status_append_invalid_root);
+
+		// append buffer can not merge PCDATA into existing PCDATA nodes
+		if ((options & parse_merge_pcdata) != 0 && last_child().type() == node_pcdata) return impl::make_parse_result(status_append_invalid_root);
 
 		// get document node
 		impl::xml_document_struct* doc = &impl::get_document(_root);
@@ -6264,7 +6637,7 @@ namespace pugi
 		doc->header |= impl::xml_memory_page_contents_shared_mask;
 
 		// get extra buffer element (we'll store the document fragment buffer there so that we can deallocate it later)
-		impl::xml_memory_page* page = 0;
+		impl::xml_memory_page* page = nullptr;
 		impl::xml_extra_buffer* extra = static_cast<impl::xml_extra_buffer*>(doc->allocate_memory(sizeof(impl::xml_extra_buffer) + sizeof(void*), page));
 		(void)page;
 
@@ -6277,7 +6650,7 @@ namespace pugi
 	#endif
 
 		// add extra buffer to the list
-		extra->buffer = 0;
+		extra->buffer = nullptr;
 		extra->next = doc->extra_buffers;
 		doc->extra_buffers = extra;
 
@@ -6287,7 +6660,7 @@ namespace pugi
 		return impl::load_buffer_impl(doc, _root, const_cast<void*>(contents), size, options, encoding, false, false, &extra->buffer);
 	}
 
-	PUGI__FN xml_node xml_node::find_child_by_attribute(const char_t* name_, const char_t* attr_name, const char_t* attr_value) const
+	PUGI_IMPL_FN xml_node xml_node::find_child_by_attribute(const char_t* name_, const char_t* attr_name, const char_t* attr_value) const
 	{
 		if (!_root) return xml_node();
 
@@ -6312,7 +6685,7 @@ namespace pugi
 		return xml_node();
 	}
 
-	PUGI__FN xml_node xml_node::find_child_by_attribute(const char_t* attr_name, const char_t* attr_value) const
+	PUGI_IMPL_FN xml_node xml_node::find_child_by_attribute(const char_t* attr_name, const char_t* attr_value) const
 	{
 		if (!_root) return xml_node();
 
@@ -6332,7 +6705,7 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN string_t xml_node::path(char_t delimiter) const
+	PUGI_IMPL_FN string_t xml_node::path(char_t delimiter) const
 	{
 		if (!_root) return string_t();
 
@@ -6369,7 +6742,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xml_node xml_node::first_element_by_path(const char_t* path_, char_t delimiter) const
+	PUGI_IMPL_FN xml_node xml_node::first_element_by_path(const char_t* path_, char_t delimiter) const
 	{
 		xml_node context = path_[0] == delimiter ? root() : *this;
 
@@ -6410,14 +6783,14 @@ namespace pugi
 		}
 	}
 
-	PUGI__FN bool xml_node::traverse(xml_tree_walker& walker)
+	PUGI_IMPL_FN bool xml_node::traverse(xml_tree_walker& walker)
 	{
 		walker._depth = -1;
 
 		xml_node arg_begin(_root);
 		if (!walker.begin(arg_begin)) return false;
 
-		xml_node_struct* cur = _root ? _root->first_child + 0 : 0;
+		xml_node_struct* cur = _root ? _root->first_child + 0 : nullptr;
 
 		if (cur)
 		{
@@ -6457,17 +6830,17 @@ namespace pugi
 		return walker.end(arg_end);
 	}
 
-	PUGI__FN size_t xml_node::hash_value() const
+	PUGI_IMPL_FN size_t xml_node::hash_value() const
 	{
-		return static_cast<size_t>(reinterpret_cast<uintptr_t>(_root) / sizeof(xml_node_struct));
+		return reinterpret_cast<uintptr_t>(_root) / sizeof(xml_node_struct);
 	}
 
-	PUGI__FN xml_node_struct* xml_node::internal_object() const
+	PUGI_IMPL_FN xml_node_struct* xml_node::internal_object() const
 	{
 		return _root;
 	}
 
-	PUGI__FN void xml_node::print(xml_writer& writer, const char_t* indent, unsigned int flags, xml_encoding encoding, unsigned int depth) const
+	PUGI_IMPL_FN void xml_node::print(xml_writer& writer, const char_t* indent, unsigned int flags, xml_encoding encoding, unsigned int depth) const
 	{
 		if (!_root) return;
 
@@ -6479,14 +6852,14 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN void xml_node::print(std::basic_ostream<char, std::char_traits<char> >& stream, const char_t* indent, unsigned int flags, xml_encoding encoding, unsigned int depth) const
+	PUGI_IMPL_FN void xml_node::print(std::basic_ostream<char>& stream, const char_t* indent, unsigned int flags, xml_encoding encoding, unsigned int depth) const
 	{
 		xml_writer_stream writer(stream);
 
 		print(writer, indent, flags, encoding, depth);
 	}
 
-	PUGI__FN void xml_node::print(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream, const char_t* indent, unsigned int flags, unsigned int depth) const
+	PUGI_IMPL_FN void xml_node::print(std::basic_ostream<wchar_t>& stream, const char_t* indent, unsigned int flags, unsigned int depth) const
 	{
 		xml_writer_stream writer(stream);
 
@@ -6494,7 +6867,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN ptrdiff_t xml_node::offset_debug() const
+	PUGI_IMPL_FN ptrdiff_t xml_node::offset_debug() const
 	{
 		if (!_root) return -1;
 
@@ -6526,37 +6899,37 @@ namespace pugi
 	}
 
 #ifdef __BORLANDC__
-	PUGI__FN bool operator&&(const xml_node& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator&&(const xml_node& lhs, bool rhs)
 	{
 		return (bool)lhs && rhs;
 	}
 
-	PUGI__FN bool operator||(const xml_node& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator||(const xml_node& lhs, bool rhs)
 	{
 		return (bool)lhs || rhs;
 	}
 #endif
 
-	PUGI__FN xml_text::xml_text(xml_node_struct* root): _root(root)
+	PUGI_IMPL_FN xml_text::xml_text(xml_node_struct* root): _root(root)
 	{
 	}
 
-	PUGI__FN xml_node_struct* xml_text::_data() const
+	PUGI_IMPL_FN xml_node_struct* xml_text::_data() const
 	{
 		if (!_root || impl::is_text_node(_root)) return _root;
 
 		// element nodes can have value if parse_embed_pcdata was used
-		if (PUGI__NODETYPE(_root) == node_element && _root->value)
+		if (PUGI_IMPL_NODETYPE(_root) == node_element && _root->value)
 			return _root;
 
 		for (xml_node_struct* node = _root->first_child; node; node = node->next_sibling)
 			if (impl::is_text_node(node))
 				return node;
 
-		return 0;
+		return nullptr;
 	}
 
-	PUGI__FN xml_node_struct* xml_text::_data_new()
+	PUGI_IMPL_FN xml_node_struct* xml_text::_data_new()
 	{
 		xml_node_struct* d = _data();
 		if (d) return d;
@@ -6564,30 +6937,30 @@ namespace pugi
 		return xml_node(_root).append_child(node_pcdata).internal_object();
 	}
 
-	PUGI__FN xml_text::xml_text(): _root(0)
+	PUGI_IMPL_FN xml_text::xml_text(): _root()
 	{
 	}
 
-	PUGI__FN static void unspecified_bool_xml_text(xml_text***)
+	PUGI_IMPL_FN static void unspecified_bool_xml_text(xml_text***)
 	{
 	}
 
-	PUGI__FN xml_text::operator xml_text::unspecified_bool_type() const
+	PUGI_IMPL_FN xml_text::operator xml_text::unspecified_bool_type() const
 	{
-		return _data() ? unspecified_bool_xml_text : 0;
+		return _data() ? unspecified_bool_xml_text : nullptr;
 	}
 
-	PUGI__FN bool xml_text::operator!() const
+	PUGI_IMPL_FN bool xml_text::operator!() const
 	{
 		return !_data();
 	}
 
-	PUGI__FN bool xml_text::empty() const
+	PUGI_IMPL_FN bool xml_text::empty() const
 	{
-		return _data() == 0;
+		return _data() == nullptr;
 	}
 
-	PUGI__FN const char_t* xml_text::get() const
+	PUGI_IMPL_FN const char_t* xml_text::get() const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return PUGIXML_TEXT("");
@@ -6595,7 +6968,7 @@ namespace pugi
 		return value ? value : PUGIXML_TEXT("");
 	}
 
-	PUGI__FN const char_t* xml_text::as_string(const char_t* def) const
+	PUGI_IMPL_FN const char_t* xml_text::as_string(const char_t* def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6603,7 +6976,7 @@ namespace pugi
 		return value ? value : def;
 	}
 
-	PUGI__FN int xml_text::as_int(int def) const
+	PUGI_IMPL_FN int xml_text::as_int(int def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6611,7 +6984,7 @@ namespace pugi
 		return value ? impl::get_value_int(value) : def;
 	}
 
-	PUGI__FN unsigned int xml_text::as_uint(unsigned int def) const
+	PUGI_IMPL_FN unsigned int xml_text::as_uint(unsigned int def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6619,7 +6992,7 @@ namespace pugi
 		return value ? impl::get_value_uint(value) : def;
 	}
 
-	PUGI__FN double xml_text::as_double(double def) const
+	PUGI_IMPL_FN double xml_text::as_double(double def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6627,7 +7000,7 @@ namespace pugi
 		return value ? impl::get_value_double(value) : def;
 	}
 
-	PUGI__FN float xml_text::as_float(float def) const
+	PUGI_IMPL_FN float xml_text::as_float(float def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6635,7 +7008,7 @@ namespace pugi
 		return value ? impl::get_value_float(value) : def;
 	}
 
-	PUGI__FN bool xml_text::as_bool(bool def) const
+	PUGI_IMPL_FN bool xml_text::as_bool(bool def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6644,7 +7017,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_LONG_LONG
-	PUGI__FN long long xml_text::as_llong(long long def) const
+	PUGI_IMPL_FN long long xml_text::as_llong(long long def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6652,7 +7025,7 @@ namespace pugi
 		return value ? impl::get_value_llong(value) : def;
 	}
 
-	PUGI__FN unsigned long long xml_text::as_ullong(unsigned long long def) const
+	PUGI_IMPL_FN unsigned long long xml_text::as_ullong(unsigned long long def) const
 	{
 		xml_node_struct* d = _data();
 		if (!d) return def;
@@ -6661,77 +7034,86 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_text::set(const char_t* rhs, size_t sz)
-	{
-		xml_node_struct* dn = _data_new();
-
-		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, sz) : false;
-	}
-
-	PUGI__FN bool xml_text::set(const char_t* rhs)
+	PUGI_IMPL_FN bool xml_text::set(const char_t* rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, impl::strlength(rhs)) : false;
 	}
 
-	PUGI__FN bool xml_text::set(int rhs)
+	PUGI_IMPL_FN bool xml_text::set(const char_t* rhs, size_t size)
+	{
+		xml_node_struct* dn = _data_new();
+
+		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, size) : false;
+	}
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN bool xml_text::set(string_view_t rhs)
+	{
+		xml_node_struct* dn = _data_new();
+
+		return dn ? impl::strcpy_insitu(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs.data(), rhs.size()) : false;
+	}
+#endif
+
+	PUGI_IMPL_FN bool xml_text::set(int rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_integer<unsigned int>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
 	}
 
-	PUGI__FN bool xml_text::set(unsigned int rhs)
+	PUGI_IMPL_FN bool xml_text::set(unsigned int rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_integer<unsigned int>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
 	}
 
-	PUGI__FN bool xml_text::set(long rhs)
+	PUGI_IMPL_FN bool xml_text::set(long rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_integer<unsigned long>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
 	}
 
-	PUGI__FN bool xml_text::set(unsigned long rhs)
+	PUGI_IMPL_FN bool xml_text::set(unsigned long rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_integer<unsigned long>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, false) : false;
 	}
 
-	PUGI__FN bool xml_text::set(float rhs)
+	PUGI_IMPL_FN bool xml_text::set(float rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, default_float_precision) : false;
 	}
 
-	PUGI__FN bool xml_text::set(float rhs, int precision)
+	PUGI_IMPL_FN bool xml_text::set(float rhs, int precision)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, precision) : false;
 	}
 
-	PUGI__FN bool xml_text::set(double rhs)
+	PUGI_IMPL_FN bool xml_text::set(double rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, default_double_precision) : false;
 	}
 
-	PUGI__FN bool xml_text::set(double rhs, int precision)
+	PUGI_IMPL_FN bool xml_text::set(double rhs, int precision)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_convert(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, precision) : false;
 	}
 
-	PUGI__FN bool xml_text::set(bool rhs)
+	PUGI_IMPL_FN bool xml_text::set(bool rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
@@ -6739,14 +7121,14 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_LONG_LONG
-	PUGI__FN bool xml_text::set(long long rhs)
+	PUGI_IMPL_FN bool xml_text::set(long long rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
 		return dn ? impl::set_value_integer<unsigned long long>(dn->value, dn->header, impl::xml_memory_page_value_allocated_mask, rhs, rhs < 0) : false;
 	}
 
-	PUGI__FN bool xml_text::set(unsigned long long rhs)
+	PUGI_IMPL_FN bool xml_text::set(unsigned long long rhs)
 	{
 		xml_node_struct* dn = _data_new();
 
@@ -6754,256 +7136,264 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xml_text& xml_text::operator=(const char_t* rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(const char_t* rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(int rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(int rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(unsigned int rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(unsigned int rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(long rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(long rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(unsigned long rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(unsigned long rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(double rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(double rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(float rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(float rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-	PUGI__FN xml_text& xml_text::operator=(bool rhs)
+	PUGI_IMPL_FN xml_text& xml_text::operator=(bool rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 
-#ifdef PUGIXML_HAS_LONG_LONG
-	PUGI__FN xml_text& xml_text::operator=(long long rhs)
-	{
-		set(rhs);
-		return *this;
-	}
-
-	PUGI__FN xml_text& xml_text::operator=(unsigned long long rhs)
+#ifdef PUGIXML_HAS_STRING_VIEW
+	PUGI_IMPL_FN xml_text& xml_text::operator=(string_view_t rhs)
 	{
 		set(rhs);
 		return *this;
 	}
 #endif
 
-	PUGI__FN xml_node xml_text::data() const
+#ifdef PUGIXML_HAS_LONG_LONG
+	PUGI_IMPL_FN xml_text& xml_text::operator=(long long rhs)
+	{
+		set(rhs);
+		return *this;
+	}
+
+	PUGI_IMPL_FN xml_text& xml_text::operator=(unsigned long long rhs)
+	{
+		set(rhs);
+		return *this;
+	}
+#endif
+
+	PUGI_IMPL_FN xml_node xml_text::data() const
 	{
 		return xml_node(_data());
 	}
 
 #ifdef __BORLANDC__
-	PUGI__FN bool operator&&(const xml_text& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator&&(const xml_text& lhs, bool rhs)
 	{
 		return (bool)lhs && rhs;
 	}
 
-	PUGI__FN bool operator||(const xml_text& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator||(const xml_text& lhs, bool rhs)
 	{
 		return (bool)lhs || rhs;
 	}
 #endif
 
-	PUGI__FN xml_node_iterator::xml_node_iterator()
+	PUGI_IMPL_FN xml_node_iterator::xml_node_iterator()
 	{
 	}
 
-	PUGI__FN xml_node_iterator::xml_node_iterator(const xml_node& node): _wrap(node), _parent(node.parent())
+	PUGI_IMPL_FN xml_node_iterator::xml_node_iterator(const xml_node& node): _wrap(node), _parent(node.parent())
 	{
 	}
 
-	PUGI__FN xml_node_iterator::xml_node_iterator(xml_node_struct* ref, xml_node_struct* parent): _wrap(ref), _parent(parent)
+	PUGI_IMPL_FN xml_node_iterator::xml_node_iterator(xml_node_struct* ref, xml_node_struct* parent): _wrap(ref), _parent(parent)
 	{
 	}
 
-	PUGI__FN bool xml_node_iterator::operator==(const xml_node_iterator& rhs) const
+	PUGI_IMPL_FN bool xml_node_iterator::operator==(const xml_node_iterator& rhs) const
 	{
 		return _wrap._root == rhs._wrap._root && _parent._root == rhs._parent._root;
 	}
 
-	PUGI__FN bool xml_node_iterator::operator!=(const xml_node_iterator& rhs) const
+	PUGI_IMPL_FN bool xml_node_iterator::operator!=(const xml_node_iterator& rhs) const
 	{
 		return _wrap._root != rhs._wrap._root || _parent._root != rhs._parent._root;
 	}
 
-	PUGI__FN xml_node& xml_node_iterator::operator*() const
+	PUGI_IMPL_FN xml_node& xml_node_iterator::operator*() const
 	{
 		assert(_wrap._root);
 		return _wrap;
 	}
 
-	PUGI__FN xml_node* xml_node_iterator::operator->() const
+	PUGI_IMPL_FN xml_node* xml_node_iterator::operator->() const
 	{
 		assert(_wrap._root);
-		return const_cast<xml_node*>(&_wrap); // BCC5 workaround
+		return &_wrap;
 	}
 
-	PUGI__FN xml_node_iterator& xml_node_iterator::operator++()
+	PUGI_IMPL_FN xml_node_iterator& xml_node_iterator::operator++()
 	{
 		assert(_wrap._root);
 		_wrap._root = _wrap._root->next_sibling;
 		return *this;
 	}
 
-	PUGI__FN xml_node_iterator xml_node_iterator::operator++(int)
+	PUGI_IMPL_FN xml_node_iterator xml_node_iterator::operator++(int)
 	{
 		xml_node_iterator temp = *this;
 		++*this;
 		return temp;
 	}
 
-	PUGI__FN xml_node_iterator& xml_node_iterator::operator--()
+	PUGI_IMPL_FN xml_node_iterator& xml_node_iterator::operator--()
 	{
 		_wrap = _wrap._root ? _wrap.previous_sibling() : _parent.last_child();
 		return *this;
 	}
 
-	PUGI__FN xml_node_iterator xml_node_iterator::operator--(int)
+	PUGI_IMPL_FN xml_node_iterator xml_node_iterator::operator--(int)
 	{
 		xml_node_iterator temp = *this;
 		--*this;
 		return temp;
 	}
 
-	PUGI__FN xml_attribute_iterator::xml_attribute_iterator()
+	PUGI_IMPL_FN xml_attribute_iterator::xml_attribute_iterator()
 	{
 	}
 
-	PUGI__FN xml_attribute_iterator::xml_attribute_iterator(const xml_attribute& attr, const xml_node& parent): _wrap(attr), _parent(parent)
+	PUGI_IMPL_FN xml_attribute_iterator::xml_attribute_iterator(const xml_attribute& attr, const xml_node& parent): _wrap(attr), _parent(parent)
 	{
 	}
 
-	PUGI__FN xml_attribute_iterator::xml_attribute_iterator(xml_attribute_struct* ref, xml_node_struct* parent): _wrap(ref), _parent(parent)
+	PUGI_IMPL_FN xml_attribute_iterator::xml_attribute_iterator(xml_attribute_struct* ref, xml_node_struct* parent): _wrap(ref), _parent(parent)
 	{
 	}
 
-	PUGI__FN bool xml_attribute_iterator::operator==(const xml_attribute_iterator& rhs) const
+	PUGI_IMPL_FN bool xml_attribute_iterator::operator==(const xml_attribute_iterator& rhs) const
 	{
 		return _wrap._attr == rhs._wrap._attr && _parent._root == rhs._parent._root;
 	}
 
-	PUGI__FN bool xml_attribute_iterator::operator!=(const xml_attribute_iterator& rhs) const
+	PUGI_IMPL_FN bool xml_attribute_iterator::operator!=(const xml_attribute_iterator& rhs) const
 	{
 		return _wrap._attr != rhs._wrap._attr || _parent._root != rhs._parent._root;
 	}
 
-	PUGI__FN xml_attribute& xml_attribute_iterator::operator*() const
+	PUGI_IMPL_FN xml_attribute& xml_attribute_iterator::operator*() const
 	{
 		assert(_wrap._attr);
 		return _wrap;
 	}
 
-	PUGI__FN xml_attribute* xml_attribute_iterator::operator->() const
+	PUGI_IMPL_FN xml_attribute* xml_attribute_iterator::operator->() const
 	{
 		assert(_wrap._attr);
-		return const_cast<xml_attribute*>(&_wrap); // BCC5 workaround
+		return &_wrap;
 	}
 
-	PUGI__FN xml_attribute_iterator& xml_attribute_iterator::operator++()
+	PUGI_IMPL_FN xml_attribute_iterator& xml_attribute_iterator::operator++()
 	{
 		assert(_wrap._attr);
 		_wrap._attr = _wrap._attr->next_attribute;
 		return *this;
 	}
 
-	PUGI__FN xml_attribute_iterator xml_attribute_iterator::operator++(int)
+	PUGI_IMPL_FN xml_attribute_iterator xml_attribute_iterator::operator++(int)
 	{
 		xml_attribute_iterator temp = *this;
 		++*this;
 		return temp;
 	}
 
-	PUGI__FN xml_attribute_iterator& xml_attribute_iterator::operator--()
+	PUGI_IMPL_FN xml_attribute_iterator& xml_attribute_iterator::operator--()
 	{
 		_wrap = _wrap._attr ? _wrap.previous_attribute() : _parent.last_attribute();
 		return *this;
 	}
 
-	PUGI__FN xml_attribute_iterator xml_attribute_iterator::operator--(int)
+	PUGI_IMPL_FN xml_attribute_iterator xml_attribute_iterator::operator--(int)
 	{
 		xml_attribute_iterator temp = *this;
 		--*this;
 		return temp;
 	}
 
-	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(): _name(0)
+	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(): _name(nullptr)
 	{
 	}
 
-	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(const xml_node& node, const char_t* name): _wrap(node), _parent(node.parent()), _name(name)
+	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(const xml_node& node, const char_t* name): _wrap(node), _parent(node.parent()), _name(name)
 	{
 	}
 
-	PUGI__FN xml_named_node_iterator::xml_named_node_iterator(xml_node_struct* ref, xml_node_struct* parent, const char_t* name): _wrap(ref), _parent(parent), _name(name)
+	PUGI_IMPL_FN xml_named_node_iterator::xml_named_node_iterator(xml_node_struct* ref, xml_node_struct* parent, const char_t* name): _wrap(ref), _parent(parent), _name(name)
 	{
 	}
 
-	PUGI__FN bool xml_named_node_iterator::operator==(const xml_named_node_iterator& rhs) const
+	PUGI_IMPL_FN bool xml_named_node_iterator::operator==(const xml_named_node_iterator& rhs) const
 	{
 		return _wrap._root == rhs._wrap._root && _parent._root == rhs._parent._root;
 	}
 
-	PUGI__FN bool xml_named_node_iterator::operator!=(const xml_named_node_iterator& rhs) const
+	PUGI_IMPL_FN bool xml_named_node_iterator::operator!=(const xml_named_node_iterator& rhs) const
 	{
 		return _wrap._root != rhs._wrap._root || _parent._root != rhs._parent._root;
 	}
 
-	PUGI__FN xml_node& xml_named_node_iterator::operator*() const
+	PUGI_IMPL_FN xml_node& xml_named_node_iterator::operator*() const
 	{
 		assert(_wrap._root);
 		return _wrap;
 	}
 
-	PUGI__FN xml_node* xml_named_node_iterator::operator->() const
+	PUGI_IMPL_FN xml_node* xml_named_node_iterator::operator->() const
 	{
 		assert(_wrap._root);
-		return const_cast<xml_node*>(&_wrap); // BCC5 workaround
+		return &_wrap;
 	}
 
-	PUGI__FN xml_named_node_iterator& xml_named_node_iterator::operator++()
+	PUGI_IMPL_FN xml_named_node_iterator& xml_named_node_iterator::operator++()
 	{
 		assert(_wrap._root);
 		_wrap = _wrap.next_sibling(_name);
 		return *this;
 	}
 
-	PUGI__FN xml_named_node_iterator xml_named_node_iterator::operator++(int)
+	PUGI_IMPL_FN xml_named_node_iterator xml_named_node_iterator::operator++(int)
 	{
 		xml_named_node_iterator temp = *this;
 		++*this;
 		return temp;
 	}
 
-	PUGI__FN xml_named_node_iterator& xml_named_node_iterator::operator--()
+	PUGI_IMPL_FN xml_named_node_iterator& xml_named_node_iterator::operator--()
 	{
 		if (_wrap._root)
 			_wrap = _wrap.previous_sibling(_name);
@@ -7018,23 +7408,23 @@ namespace pugi
 		return *this;
 	}
 
-	PUGI__FN xml_named_node_iterator xml_named_node_iterator::operator--(int)
+	PUGI_IMPL_FN xml_named_node_iterator xml_named_node_iterator::operator--(int)
 	{
 		xml_named_node_iterator temp = *this;
 		--*this;
 		return temp;
 	}
 
-	PUGI__FN xml_parse_result::xml_parse_result(): status(status_internal_error), offset(0), encoding(encoding_auto)
+	PUGI_IMPL_FN xml_parse_result::xml_parse_result(): status(status_internal_error), offset(0), encoding(encoding_auto)
 	{
 	}
 
-	PUGI__FN xml_parse_result::operator bool() const
+	PUGI_IMPL_FN xml_parse_result::operator bool() const
 	{
 		return status == status_ok;
 	}
 
-	PUGI__FN const char* xml_parse_result::description() const
+	PUGI_IMPL_FN const char* xml_parse_result::description() const
 	{
 		switch (status)
 		{
@@ -7065,24 +7455,24 @@ namespace pugi
 		}
 	}
 
-	PUGI__FN xml_document::xml_document(): _buffer(0)
+	PUGI_IMPL_FN xml_document::xml_document(): _buffer(nullptr)
 	{
 		_create();
 	}
 
-	PUGI__FN xml_document::~xml_document()
+	PUGI_IMPL_FN xml_document::~xml_document()
 	{
 		_destroy();
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(0)
+	PUGI_IMPL_FN xml_document::xml_document(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT: _buffer(nullptr)
 	{
 		_create();
 		_move(rhs);
 	}
 
-	PUGI__FN xml_document& xml_document::operator=(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT
+	PUGI_IMPL_FN xml_document& xml_document::operator=(xml_document&& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT
 	{
 		if (this == &rhs) return *this;
 
@@ -7094,20 +7484,20 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN void xml_document::reset()
+	PUGI_IMPL_FN void xml_document::reset()
 	{
 		_destroy();
 		_create();
 	}
 
-	PUGI__FN void xml_document::reset(const xml_document& proto)
+	PUGI_IMPL_FN void xml_document::reset(const xml_document& proto)
 	{
 		reset();
 
 		impl::node_copy_tree(_root, proto._root);
 	}
 
-	PUGI__FN void xml_document::_create()
+	PUGI_IMPL_FN void xml_document::_create()
 	{
 		assert(!_root);
 
@@ -7119,7 +7509,7 @@ namespace pugi
 	#endif
 
 		// initialize sentinel page
-		PUGI__STATIC_ASSERT(sizeof(impl::xml_memory_page) + sizeof(impl::xml_document_struct) + page_offset <= sizeof(_memory));
+		PUGI_IMPL_STATIC_ASSERT(sizeof(impl::xml_memory_page) + sizeof(impl::xml_document_struct) + page_offset <= sizeof(_memory));
 
 		// prepare page structure
 		impl::xml_memory_page* page = impl::xml_memory_page::construct(_memory);
@@ -7150,7 +7540,7 @@ namespace pugi
 		assert(reinterpret_cast<char*>(_root) + sizeof(impl::xml_document_struct) <= _memory + sizeof(_memory));
 	}
 
-	PUGI__FN void xml_document::_destroy()
+	PUGI_IMPL_FN void xml_document::_destroy()
 	{
 		assert(_root);
 
@@ -7158,7 +7548,7 @@ namespace pugi
 		if (_buffer)
 		{
 			impl::xml_memory::deallocate(_buffer);
-			_buffer = 0;
+			_buffer = nullptr;
 		}
 
 		// destroy extra buffers (note: no need to destroy linked list nodes, they're allocated using document allocator)
@@ -7168,7 +7558,7 @@ namespace pugi
 		}
 
 		// destroy dynamic storage, leave sentinel page (it's in static memory)
-		impl::xml_memory_page* root_page = PUGI__GETPAGE(_root);
+		impl::xml_memory_page* root_page = PUGI_IMPL_GETPAGE(_root);
 		assert(root_page && !root_page->prev);
 		assert(reinterpret_cast<char*>(root_page) >= _memory && reinterpret_cast<char*>(root_page) < _memory + sizeof(_memory));
 
@@ -7186,11 +7576,11 @@ namespace pugi
 		static_cast<impl::xml_document_struct*>(_root)->hash.clear();
 	#endif
 
-		_root = 0;
+		_root = nullptr;
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN void xml_document::_move(xml_document& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT
+	PUGI_IMPL_FN void xml_document::_move(xml_document& rhs) PUGIXML_NOEXCEPT_IF_NOT_COMPACT
 	{
 		impl::xml_document_struct* doc = static_cast<impl::xml_document_struct*>(_root);
 		impl::xml_document_struct* other = static_cast<impl::xml_document_struct*>(rhs._root);
@@ -7224,7 +7614,7 @@ namespace pugi
 
 		// move allocation state
 		// note that other->_root may point to the embedded document page, in which case we should keep original (empty) state
-		if (other->_root != PUGI__GETPAGE(other))
+		if (other->_root != PUGI_IMPL_GETPAGE(other))
 		{
 			doc->_root = other->_root;
 			doc->_busy_size = other->_busy_size;
@@ -7241,14 +7631,14 @@ namespace pugi
 		doc->_hash = &doc->hash;
 
 		// make sure we don't access other hash up until the end when we reinitialize other document
-		other->_hash = 0;
+		other->_hash = nullptr;
 	#endif
 
 		// move page structure
-		impl::xml_memory_page* doc_page = PUGI__GETPAGE(doc);
+		impl::xml_memory_page* doc_page = PUGI_IMPL_GETPAGE(doc);
 		assert(doc_page && !doc_page->prev && !doc_page->next);
 
-		impl::xml_memory_page* other_page = PUGI__GETPAGE(other);
+		impl::xml_memory_page* other_page = PUGI_IMPL_GETPAGE(other);
 		assert(other_page && !other_page->prev);
 
 		// relink pages since root page is embedded into xml_document
@@ -7259,7 +7649,7 @@ namespace pugi
 			page->prev = doc_page;
 
 			doc_page->next = page;
-			other_page->next = 0;
+			other_page->next = nullptr;
 		}
 
 		// make sure pages point to the correct document state
@@ -7295,20 +7685,20 @@ namespace pugi
 		}
 
 		// reset other document
-		new (other) impl::xml_document_struct(PUGI__GETPAGE(other));
-		rhs._buffer = 0;
+		new (other) impl::xml_document_struct(PUGI_IMPL_GETPAGE(other));
+		rhs._buffer = nullptr;
 	}
 #endif
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN xml_parse_result xml_document::load(std::basic_istream<char, std::char_traits<char> >& stream, unsigned int options, xml_encoding encoding)
+	PUGI_IMPL_FN xml_parse_result xml_document::load(std::basic_istream<char>& stream, unsigned int options, xml_encoding encoding)
 	{
 		reset();
 
 		return impl::load_stream_impl(static_cast<impl::xml_document_struct*>(_root), stream, options, encoding, &_buffer);
 	}
 
-	PUGI__FN xml_parse_result xml_document::load(std::basic_istream<wchar_t, std::char_traits<wchar_t> >& stream, unsigned int options)
+	PUGI_IMPL_FN xml_parse_result xml_document::load(std::basic_istream<wchar_t>& stream, unsigned int options)
 	{
 		reset();
 
@@ -7316,7 +7706,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xml_parse_result xml_document::load_string(const char_t* contents, unsigned int options)
+	PUGI_IMPL_FN xml_parse_result xml_document::load_string(const char_t* contents, unsigned int options)
 	{
 		// Force native encoding (skip autodetection)
 	#ifdef PUGIXML_WCHAR_MODE
@@ -7328,12 +7718,12 @@ namespace pugi
 		return load_buffer(contents, impl::strlength(contents) * sizeof(char_t), options, encoding);
 	}
 
-	PUGI__FN xml_parse_result xml_document::load(const char_t* contents, unsigned int options)
+	PUGI_IMPL_FN xml_parse_result xml_document::load(const char_t* contents, unsigned int options)
 	{
 		return load_string(contents, options);
 	}
 
-	PUGI__FN xml_parse_result xml_document::load_file(const char* path_, unsigned int options, xml_encoding encoding)
+	PUGI_IMPL_FN xml_parse_result xml_document::load_file(const char* path_, unsigned int options, xml_encoding encoding)
 	{
 		reset();
 
@@ -7343,7 +7733,7 @@ namespace pugi
 		return impl::load_file_impl(static_cast<impl::xml_document_struct*>(_root), file.data, options, encoding, &_buffer);
 	}
 
-	PUGI__FN xml_parse_result xml_document::load_file(const wchar_t* path_, unsigned int options, xml_encoding encoding)
+	PUGI_IMPL_FN xml_parse_result xml_document::load_file(const wchar_t* path_, unsigned int options, xml_encoding encoding)
 	{
 		reset();
 
@@ -7353,32 +7743,32 @@ namespace pugi
 		return impl::load_file_impl(static_cast<impl::xml_document_struct*>(_root), file.data, options, encoding, &_buffer);
 	}
 
-	PUGI__FN xml_parse_result xml_document::load_buffer(const void* contents, size_t size, unsigned int options, xml_encoding encoding)
+	PUGI_IMPL_FN xml_parse_result xml_document::load_buffer(const void* contents, size_t size, unsigned int options, xml_encoding encoding)
 	{
 		reset();
 
 		return impl::load_buffer_impl(static_cast<impl::xml_document_struct*>(_root), _root, const_cast<void*>(contents), size, options, encoding, false, false, &_buffer);
 	}
 
-	PUGI__FN xml_parse_result xml_document::load_buffer_inplace(void* contents, size_t size, unsigned int options, xml_encoding encoding)
+	PUGI_IMPL_FN xml_parse_result xml_document::load_buffer_inplace(void* contents, size_t size, unsigned int options, xml_encoding encoding)
 	{
 		reset();
 
 		return impl::load_buffer_impl(static_cast<impl::xml_document_struct*>(_root), _root, contents, size, options, encoding, true, false, &_buffer);
 	}
 
-	PUGI__FN xml_parse_result xml_document::load_buffer_inplace_own(void* contents, size_t size, unsigned int options, xml_encoding encoding)
+	PUGI_IMPL_FN xml_parse_result xml_document::load_buffer_inplace_own(void* contents, size_t size, unsigned int options, xml_encoding encoding)
 	{
 		reset();
 
 		return impl::load_buffer_impl(static_cast<impl::xml_document_struct*>(_root), _root, contents, size, options, encoding, true, true, &_buffer);
 	}
 
-	PUGI__FN void xml_document::save(xml_writer& writer, const char_t* indent, unsigned int flags, xml_encoding encoding) const
+	PUGI_IMPL_FN void xml_document::save(xml_writer& writer, const char_t* indent, unsigned int flags, xml_encoding encoding) const
 	{
 		impl::xml_buffered_writer buffered_writer(writer, encoding);
 
-		if ((flags & format_write_bom) && encoding != encoding_latin1)
+		if ((flags & format_write_bom) && buffered_writer.encoding != encoding_latin1)
 		{
 			// BOM always represents the codepoint U+FEFF, so just write it in native encoding
 		#ifdef PUGIXML_WCHAR_MODE
@@ -7392,7 +7782,7 @@ namespace pugi
 		if (!(flags & format_no_declaration) && !impl::has_declaration(_root))
 		{
 			buffered_writer.write_string(PUGIXML_TEXT("<?xml version=\"1.0\""));
-			if (encoding == encoding_latin1) buffered_writer.write_string(PUGIXML_TEXT(" encoding=\"ISO-8859-1\""));
+			if (buffered_writer.encoding == encoding_latin1) buffered_writer.write_string(PUGIXML_TEXT(" encoding=\"ISO-8859-1\""));
 			buffered_writer.write('?', '>');
 			if (!(flags & format_raw)) buffered_writer.write('\n');
 		}
@@ -7403,14 +7793,14 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN void xml_document::save(std::basic_ostream<char, std::char_traits<char> >& stream, const char_t* indent, unsigned int flags, xml_encoding encoding) const
+	PUGI_IMPL_FN void xml_document::save(std::basic_ostream<char>& stream, const char_t* indent, unsigned int flags, xml_encoding encoding) const
 	{
 		xml_writer_stream writer(stream);
 
 		save(writer, indent, flags, encoding);
 	}
 
-	PUGI__FN void xml_document::save(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream, const char_t* indent, unsigned int flags) const
+	PUGI_IMPL_FN void xml_document::save(std::basic_ostream<wchar_t>& stream, const char_t* indent, unsigned int flags) const
 	{
 		xml_writer_stream writer(stream);
 
@@ -7418,7 +7808,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN bool xml_document::save_file(const char* path_, const char_t* indent, unsigned int flags, xml_encoding encoding) const
+	PUGI_IMPL_FN bool xml_document::save_file(const char* path_, const char_t* indent, unsigned int flags, xml_encoding encoding) const
 	{
 		using impl::auto_deleter; // MSVC7 workaround
 		auto_deleter<FILE> file(impl::open_file(path_, (flags & format_save_file_text) ? "w" : "wb"), impl::close_file);
@@ -7426,7 +7816,7 @@ namespace pugi
 		return impl::save_file_impl(*this, file.data, indent, flags, encoding) && fclose(file.release()) == 0;
 	}
 
-	PUGI__FN bool xml_document::save_file(const wchar_t* path_, const char_t* indent, unsigned int flags, xml_encoding encoding) const
+	PUGI_IMPL_FN bool xml_document::save_file(const wchar_t* path_, const char_t* indent, unsigned int flags, xml_encoding encoding) const
 	{
 		using impl::auto_deleter; // MSVC7 workaround
 		auto_deleter<FILE> file(impl::open_file_wide(path_, (flags & format_save_file_text) ? L"w" : L"wb"), impl::close_file);
@@ -7434,55 +7824,55 @@ namespace pugi
 		return impl::save_file_impl(*this, file.data, indent, flags, encoding) && fclose(file.release()) == 0;
 	}
 
-	PUGI__FN xml_node xml_document::document_element() const
+	PUGI_IMPL_FN xml_node xml_document::document_element() const
 	{
 		assert(_root);
 
 		for (xml_node_struct* i = _root->first_child; i; i = i->next_sibling)
-			if (PUGI__NODETYPE(i) == node_element)
+			if (PUGI_IMPL_NODETYPE(i) == node_element)
 				return xml_node(i);
 
 		return xml_node();
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN std::string PUGIXML_FUNCTION as_utf8(const wchar_t* str)
+	PUGI_IMPL_FN std::string PUGIXML_FUNCTION as_utf8(const wchar_t* str)
 	{
 		assert(str);
 
 		return impl::as_utf8_impl(str, impl::strlength_wide(str));
 	}
 
-	PUGI__FN std::string PUGIXML_FUNCTION as_utf8(const std::basic_string<wchar_t>& str)
+	PUGI_IMPL_FN std::string PUGIXML_FUNCTION as_utf8(const std::basic_string<wchar_t>& str)
 	{
 		return impl::as_utf8_impl(str.c_str(), str.size());
 	}
 
-	PUGI__FN std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const char* str)
+	PUGI_IMPL_FN std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const char* str)
 	{
 		assert(str);
 
 		return impl::as_wide_impl(str, strlen(str));
 	}
 
-	PUGI__FN std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const std::string& str)
+	PUGI_IMPL_FN std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const std::string& str)
 	{
 		return impl::as_wide_impl(str.c_str(), str.size());
 	}
 #endif
 
-	PUGI__FN void PUGIXML_FUNCTION set_memory_management_functions(allocation_function allocate, deallocation_function deallocate)
+	PUGI_IMPL_FN void PUGIXML_FUNCTION set_memory_management_functions(allocation_function allocate, deallocation_function deallocate)
 	{
 		impl::xml_memory::allocate = allocate;
 		impl::xml_memory::deallocate = deallocate;
 	}
 
-	PUGI__FN allocation_function PUGIXML_FUNCTION get_memory_allocation_function()
+	PUGI_IMPL_FN allocation_function PUGIXML_FUNCTION get_memory_allocation_function()
 	{
 		return impl::xml_memory::allocate;
 	}
 
-	PUGI__FN deallocation_function PUGIXML_FUNCTION get_memory_deallocation_function()
+	PUGI_IMPL_FN deallocation_function PUGIXML_FUNCTION get_memory_deallocation_function()
 	{
 		return impl::xml_memory::deallocate;
 	}
@@ -7492,17 +7882,17 @@ namespace pugi
 namespace std
 {
 	// Workarounds for (non-standard) iterator category detection for older versions (MSVC7/IC8 and earlier)
-	PUGI__FN std::bidirectional_iterator_tag _Iter_cat(const pugi::xml_node_iterator&)
+	PUGI_IMPL_FN std::bidirectional_iterator_tag _Iter_cat(const pugi::xml_node_iterator&)
 	{
 		return std::bidirectional_iterator_tag();
 	}
 
-	PUGI__FN std::bidirectional_iterator_tag _Iter_cat(const pugi::xml_attribute_iterator&)
+	PUGI_IMPL_FN std::bidirectional_iterator_tag _Iter_cat(const pugi::xml_attribute_iterator&)
 	{
 		return std::bidirectional_iterator_tag();
 	}
 
-	PUGI__FN std::bidirectional_iterator_tag _Iter_cat(const pugi::xml_named_node_iterator&)
+	PUGI_IMPL_FN std::bidirectional_iterator_tag _Iter_cat(const pugi::xml_named_node_iterator&)
 	{
 		return std::bidirectional_iterator_tag();
 	}
@@ -7513,17 +7903,17 @@ namespace std
 namespace std
 {
 	// Workarounds for (non-standard) iterator category detection
-	PUGI__FN std::bidirectional_iterator_tag __iterator_category(const pugi::xml_node_iterator&)
+	PUGI_IMPL_FN std::bidirectional_iterator_tag __iterator_category(const pugi::xml_node_iterator&)
 	{
 		return std::bidirectional_iterator_tag();
 	}
 
-	PUGI__FN std::bidirectional_iterator_tag __iterator_category(const pugi::xml_attribute_iterator&)
+	PUGI_IMPL_FN std::bidirectional_iterator_tag __iterator_category(const pugi::xml_attribute_iterator&)
 	{
 		return std::bidirectional_iterator_tag();
 	}
 
-	PUGI__FN std::bidirectional_iterator_tag __iterator_category(const pugi::xml_named_node_iterator&)
+	PUGI_IMPL_FN std::bidirectional_iterator_tag __iterator_category(const pugi::xml_named_node_iterator&)
 	{
 		return std::bidirectional_iterator_tag();
 	}
@@ -7532,7 +7922,7 @@ namespace std
 
 #ifndef PUGIXML_NO_XPATH
 // STL replacements
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	struct equal_to
 	{
 		template <typename T> bool operator()(const T& lhs, const T& rhs) const
@@ -7572,7 +7962,7 @@ PUGI__NS_BEGIN
 		rhs = temp;
 	}
 
-	template <typename I, typename Pred> PUGI__FN I min_element(I begin, I end, const Pred& pred)
+	template <typename I, typename Pred> PUGI_IMPL_FN I min_element(I begin, I end, const Pred& pred)
 	{
 		I result = begin;
 
@@ -7583,13 +7973,13 @@ PUGI__NS_BEGIN
 		return result;
 	}
 
-	template <typename I> PUGI__FN void reverse(I begin, I end)
+	template <typename I> PUGI_IMPL_FN void reverse(I begin, I end)
 	{
 		while (end - begin > 1)
 			swap(*begin++, *--end);
 	}
 
-	template <typename I> PUGI__FN I unique(I begin, I end)
+	template <typename I> PUGI_IMPL_FN I unique(I begin, I end)
 	{
 		// fast skip head
 		while (end - begin > 1 && *begin != *(begin + 1))
@@ -7614,7 +8004,7 @@ PUGI__NS_BEGIN
 		return write + 1;
 	}
 
-	template <typename T, typename Pred> PUGI__FN void insertion_sort(T* begin, T* end, const Pred& pred)
+	template <typename T, typename Pred> PUGI_IMPL_FN void insertion_sort(T* begin, T* end, const Pred& pred)
 	{
 		if (begin == end)
 			return;
@@ -7648,7 +8038,7 @@ PUGI__NS_BEGIN
 		return middle;
 	}
 
-	template <typename T, typename Pred> PUGI__FN void partition3(T* begin, T* end, T pivot, const Pred& pred, T** out_eqbeg, T** out_eqend)
+	template <typename T, typename Pred> PUGI_IMPL_FN void partition3(T* begin, T* end, T pivot, const Pred& pred, T** out_eqbeg, T** out_eqend)
 	{
 		// invariant: array is split into 4 groups: = < ? > (each variable denotes the boundary between the groups)
 		T* eq = begin;
@@ -7675,7 +8065,7 @@ PUGI__NS_BEGIN
 		*out_eqend = gt;
 	}
 
-	template <typename I, typename Pred> PUGI__FN void sort(I begin, I end, const Pred& pred)
+	template <typename I, typename Pred> PUGI_IMPL_FN void sort(I begin, I end, const Pred& pred)
 	{
 		// sort large chunks
 		while (end - begin > 16)
@@ -7705,7 +8095,7 @@ PUGI__NS_BEGIN
 		insertion_sort(begin, end, pred);
 	}
 
-	PUGI__FN bool hash_insert(const void** table, size_t size, const void* key)
+	PUGI_IMPL_FN bool hash_insert(const void** table, size_t size, const void* key)
 	{
 		assert(key);
 
@@ -7723,7 +8113,7 @@ PUGI__NS_BEGIN
 
 		for (size_t probe = 0; probe <= hashmod; ++probe)
 		{
-			if (table[bucket] == 0)
+			if (table[bucket] == nullptr)
 			{
 				table[bucket] = key;
 				return true;
@@ -7739,10 +8129,10 @@ PUGI__NS_BEGIN
 		assert(false && "Hash table is full"); // unreachable
 		return false;
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // Allocator used for AST and evaluation stacks
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	static const size_t xpath_memory_page_size =
 	#ifdef PUGIXML_MEMORY_XPATH_PAGE_SIZE
 		PUGIXML_MEMORY_XPATH_PAGE_SIZE
@@ -7771,7 +8161,7 @@ PUGI__NS_BEGIN
 		size_t _root_size;
 		bool* _error;
 
-		xpath_allocator(xpath_memory_block* root, bool* error = 0): _root(root), _root_size(0), _error(error)
+		xpath_allocator(xpath_memory_block* root, bool* error = nullptr): _root(root), _root_size(0), _error(error)
 		{
 		}
 
@@ -7799,7 +8189,7 @@ PUGI__NS_BEGIN
 				if (!block)
 				{
 					if (_error) *_error = true;
-					return 0;
+					return nullptr;
 				}
 
 				block->next = _root;
@@ -7819,7 +8209,7 @@ PUGI__NS_BEGIN
 			new_size = (new_size + xpath_memory_block_alignment - 1) & ~(xpath_memory_block_alignment - 1);
 
 			// we can only reallocate the last object
-			assert(ptr == 0 || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
+			assert(ptr == nullptr || static_cast<char*>(ptr) + old_size == &_root->data[0] + _root_size);
 
 			// try to reallocate the object inplace
 			if (ptr && _root_size - old_size + new_size <= _root->capacity)
@@ -7830,7 +8220,7 @@ PUGI__NS_BEGIN
 
 			// allocate a new block
 			void* result = allocate(new_size);
-			if (!result) return 0;
+			if (!result) return nullptr;
 
 			// we have a new block
 			if (ptr)
@@ -7925,7 +8315,7 @@ PUGI__NS_BEGIN
 
 		xpath_stack_data(): result(blocks + 0, &oom), temp(blocks + 1, &oom), oom(false)
 		{
-			blocks[0].next = blocks[1].next = 0;
+			blocks[0].next = blocks[1].next = nullptr;
 			blocks[0].capacity = blocks[1].capacity = sizeof(blocks[0].data);
 
 			stack.result = &result;
@@ -7938,10 +8328,10 @@ PUGI__NS_BEGIN
 			temp.release();
 		}
 	};
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // String class
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	class xpath_string
 	{
 		const char_t* _buffer;
@@ -7951,7 +8341,7 @@ PUGI__NS_BEGIN
 		static char_t* duplicate_string(const char_t* string, size_t length, xpath_allocator* alloc)
 		{
 			char_t* result = static_cast<char_t*>(alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!result) return 0;
+			if (!result) return nullptr;
 
 			memcpy(result, string, length * sizeof(char_t));
 			result[length] = 0;
@@ -8011,7 +8401,7 @@ PUGI__NS_BEGIN
 				size_t result_length = target_length + source_length;
 
 				// allocate new buffer
-				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : 0, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
+				char_t* result = static_cast<char_t*>(alloc->reallocate(_uses_heap ? const_cast<char_t*>(_buffer) : nullptr, (target_length + 1) * sizeof(char_t), (result_length + 1) * sizeof(char_t)));
 				if (!result) return;
 
 				// append first string to the new buffer in case there was no reallocation
@@ -8046,7 +8436,7 @@ PUGI__NS_BEGIN
 				size_t length_ = strlength(_buffer);
 				const char_t* data_ = duplicate_string(_buffer, length_, alloc);
 
-				if (!data_) return 0;
+				if (!data_) return nullptr;
 
 				_buffer = data_;
 				_uses_heap = true;
@@ -8076,10 +8466,10 @@ PUGI__NS_BEGIN
 			return _uses_heap;
 		}
 	};
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
-PUGI__NS_BEGIN
-	PUGI__FN bool starts_with(const char_t* string, const char_t* pattern)
+PUGI_IMPL_NS_BEGIN
+	PUGI_IMPL_FN bool starts_with(const char_t* string, const char_t* pattern)
 	{
 		while (*pattern && *string == *pattern)
 		{
@@ -8090,7 +8480,7 @@ PUGI__NS_BEGIN
 		return *pattern == 0;
 	}
 
-	PUGI__FN const char_t* find_char(const char_t* s, char_t c)
+	PUGI_IMPL_FN const char_t* find_char(const char_t* s, char_t c)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
 		return wcschr(s, c);
@@ -8099,7 +8489,7 @@ PUGI__NS_BEGIN
 	#endif
 	}
 
-	PUGI__FN const char_t* find_substring(const char_t* s, const char_t* p)
+	PUGI_IMPL_FN const char_t* find_substring(const char_t* s, const char_t* p)
 	{
 	#ifdef PUGIXML_WCHAR_MODE
 		// MSVC6 wcsstr bug workaround (if s is empty it always returns 0)
@@ -8110,12 +8500,12 @@ PUGI__NS_BEGIN
 	}
 
 	// Converts symbol to lower case, if it is an ASCII one
-	PUGI__FN char_t tolower_ascii(char_t ch)
+	PUGI_IMPL_FN char_t tolower_ascii(char_t ch)
 	{
 		return static_cast<unsigned int>(ch - 'A') < 26 ? static_cast<char_t>(ch | ' ') : ch;
 	}
 
-	PUGI__FN xpath_string string_value(const xpath_node& na, xpath_allocator* alloc)
+	PUGI_IMPL_FN xpath_string string_value(const xpath_node& na, xpath_allocator* alloc)
 	{
 		if (na.attribute())
 			return xpath_string::from_const(na.attribute().value());
@@ -8169,7 +8559,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN bool node_is_before_sibling(xml_node_struct* ln, xml_node_struct* rn)
+	PUGI_IMPL_FN bool node_is_before_sibling(xml_node_struct* ln, xml_node_struct* rn)
 	{
 		assert(ln->parent == rn->parent);
 
@@ -8193,7 +8583,7 @@ PUGI__NS_BEGIN
 		return !rs;
 	}
 
-	PUGI__FN bool node_is_before(xml_node_struct* ln, xml_node_struct* rn)
+	PUGI_IMPL_FN bool node_is_before(xml_node_struct* ln, xml_node_struct* rn)
 	{
 		// find common ancestor at the same depth, if any
 		xml_node_struct* lp = ln;
@@ -8236,14 +8626,14 @@ PUGI__NS_BEGIN
 		return node_is_before_sibling(ln, rn);
 	}
 
-	PUGI__FN bool node_is_ancestor(xml_node_struct* parent, xml_node_struct* node)
+	PUGI_IMPL_FN bool node_is_ancestor(xml_node_struct* parent, xml_node_struct* node)
 	{
 		while (node && node != parent) node = node->parent;
 
 		return parent && node == parent;
 	}
 
-	PUGI__FN const void* document_buffer_order(const xpath_node& xnode)
+	PUGI_IMPL_FN const void* document_buffer_order(const xpath_node& xnode)
 	{
 		xml_node_struct* node = xnode.node().internal_object();
 
@@ -8255,7 +8645,7 @@ PUGI__NS_BEGIN
 				if (node->value && (node->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return node->value;
 			}
 
-			return 0;
+			return nullptr;
 		}
 
 		xml_attribute_struct* attr = xnode.attribute().internal_object();
@@ -8268,10 +8658,10 @@ PUGI__NS_BEGIN
 				if ((attr->header & impl::xml_memory_page_value_allocated_or_shared_mask) == 0) return attr->value;
 			}
 
-			return 0;
+			return nullptr;
 		}
 
-		return 0;
+		return nullptr;
 	}
 
 	struct document_order_comparator
@@ -8328,10 +8718,10 @@ PUGI__NS_BEGIN
 		}
 	};
 
-	PUGI__FN double gen_nan()
+	PUGI_IMPL_FN double gen_nan()
 	{
 	#if defined(__STDC_IEC_559__) || ((FLT_RADIX - 0 == 2) && (FLT_MAX_EXP - 0 == 128) && (FLT_MANT_DIG - 0 == 24))
-		PUGI__STATIC_ASSERT(sizeof(float) == sizeof(uint32_t));
+		PUGI_IMPL_STATIC_ASSERT(sizeof(float) == sizeof(uint32_t));
 		typedef uint32_t UI; // BCC5 workaround
 		union { float f; UI i; } u;
 		u.i = 0x7fc00000;
@@ -8343,9 +8733,9 @@ PUGI__NS_BEGIN
 	#endif
 	}
 
-	PUGI__FN bool is_nan(double value)
+	PUGI_IMPL_FN bool is_nan(double value)
 	{
-	#if defined(PUGI__MSVC_CRT_VERSION) || defined(__BORLANDC__)
+	#if defined(PUGI_IMPL_MSVC_CRT_VERSION) || defined(__BORLANDC__)
 		return !!_isnan(value);
 	#elif defined(fpclassify) && defined(FP_NAN)
 		return fpclassify(value) == FP_NAN;
@@ -8356,9 +8746,9 @@ PUGI__NS_BEGIN
 	#endif
 	}
 
-	PUGI__FN const char_t* convert_number_to_string_special(double value)
+	PUGI_IMPL_FN const char_t* convert_number_to_string_special(double value)
 	{
-	#if defined(PUGI__MSVC_CRT_VERSION) || defined(__BORLANDC__)
+	#if defined(PUGI_IMPL_MSVC_CRT_VERSION) || defined(__BORLANDC__)
 		if (_finite(value)) return (value == 0) ? PUGIXML_TEXT("0") : 0;
 		if (_isnan(value)) return PUGIXML_TEXT("NaN");
 		return value > 0 ? PUGIXML_TEXT("Infinity") : PUGIXML_TEXT("-Infinity");
@@ -8384,16 +8774,16 @@ PUGI__NS_BEGIN
 		if (v == 0) return PUGIXML_TEXT("0");
 		if (v != v) return PUGIXML_TEXT("NaN");
 		if (v * 2 == v) return value > 0 ? PUGIXML_TEXT("Infinity") : PUGIXML_TEXT("-Infinity");
-		return 0;
+		return nullptr;
 	#endif
 	}
 
-	PUGI__FN bool convert_number_to_boolean(double value)
+	PUGI_IMPL_FN bool convert_number_to_boolean(double value)
 	{
 		return (value != 0 && !is_nan(value));
 	}
 
-	PUGI__FN void truncate_zeros(char* begin, char* end)
+	PUGI_IMPL_FN void truncate_zeros(char* begin, char* end)
 	{
 		while (begin != end && end[-1] == '0') end--;
 
@@ -8401,8 +8791,8 @@ PUGI__NS_BEGIN
 	}
 
 	// gets mantissa digits in the form of 0.xxxxx with 0. implied and the exponent
-#if defined(PUGI__MSVC_CRT_VERSION) && PUGI__MSVC_CRT_VERSION >= 1400
-	PUGI__FN void convert_number_to_mantissa_exponent(double value, char (&buffer)[32], char** out_mantissa, int* out_exponent)
+#if defined(PUGI_IMPL_MSVC_CRT_VERSION) && PUGI_IMPL_MSVC_CRT_VERSION >= 1400
+	PUGI_IMPL_FN void convert_number_to_mantissa_exponent(double value, char (&buffer)[32], char** out_mantissa, int* out_exponent)
 	{
 		// get base values
 		int sign, exponent;
@@ -8416,10 +8806,10 @@ PUGI__NS_BEGIN
 		*out_exponent = exponent;
 	}
 #else
-	PUGI__FN void convert_number_to_mantissa_exponent(double value, char (&buffer)[32], char** out_mantissa, int* out_exponent)
+	PUGI_IMPL_FN void convert_number_to_mantissa_exponent(double value, char (&buffer)[32], char** out_mantissa, int* out_exponent)
 	{
 		// get a scientific notation value with IEEE DBL_DIG decimals
-		PUGI__SNPRINTF(buffer, "%.*e", DBL_DIG, value);
+		PUGI_IMPL_SNPRINTF(buffer, "%.*e", DBL_DIG, value);
 
 		// get the exponent (possibly negative)
 		char* exponent_string = strchr(buffer, 'e');
@@ -8429,7 +8819,7 @@ PUGI__NS_BEGIN
 
 		// extract mantissa string: skip sign
 		char* mantissa = buffer[0] == '-' ? buffer + 1 : buffer;
-		assert(mantissa[0] != '0' && mantissa[1] == '.');
+		assert(mantissa[0] != '0' && (mantissa[1] == '.' || mantissa[1] == ','));
 
 		// divide mantissa by 10 to eliminate integer part
 		mantissa[1] = mantissa[0];
@@ -8445,7 +8835,7 @@ PUGI__NS_BEGIN
 	}
 #endif
 
-	PUGI__FN xpath_string convert_number_to_string(double value, xpath_allocator* alloc)
+	PUGI_IMPL_FN xpath_string convert_number_to_string(double value, xpath_allocator* alloc)
 	{
 		// try special number conversion
 		const char_t* special = convert_number_to_string_special(value);
@@ -8512,10 +8902,10 @@ PUGI__NS_BEGIN
 		return xpath_string::from_heap_preallocated(result, s);
 	}
 
-	PUGI__FN bool check_string_to_number_format(const char_t* string)
+	PUGI_IMPL_FN bool check_string_to_number_format(const char_t* string)
 	{
 		// parse leading whitespace
-		while (PUGI__IS_CHARTYPE(*string, ct_space)) ++string;
+		while (PUGI_IMPL_IS_CHARTYPE(*string, ct_space)) ++string;
 
 		// parse sign
 		if (*string == '-') ++string;
@@ -8523,39 +8913,39 @@ PUGI__NS_BEGIN
 		if (!*string) return false;
 
 		// if there is no integer part, there should be a decimal part with at least one digit
-		if (!PUGI__IS_CHARTYPEX(string[0], ctx_digit) && (string[0] != '.' || !PUGI__IS_CHARTYPEX(string[1], ctx_digit))) return false;
+		if (!PUGI_IMPL_IS_CHARTYPEX(string[0], ctx_digit) && (string[0] != '.' || !PUGI_IMPL_IS_CHARTYPEX(string[1], ctx_digit))) return false;
 
 		// parse integer part
-		while (PUGI__IS_CHARTYPEX(*string, ctx_digit)) ++string;
+		while (PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) ++string;
 
 		// parse decimal part
 		if (*string == '.')
 		{
 			++string;
 
-			while (PUGI__IS_CHARTYPEX(*string, ctx_digit)) ++string;
+			while (PUGI_IMPL_IS_CHARTYPEX(*string, ctx_digit)) ++string;
 		}
 
 		// parse trailing whitespace
-		while (PUGI__IS_CHARTYPE(*string, ct_space)) ++string;
+		while (PUGI_IMPL_IS_CHARTYPE(*string, ct_space)) ++string;
 
 		return *string == 0;
 	}
 
-	PUGI__FN double convert_string_to_number(const char_t* string)
+	PUGI_IMPL_FN double convert_string_to_number(const char_t* string)
 	{
 		// check string format
 		if (!check_string_to_number_format(string)) return gen_nan();
 
 		// parse string
 	#ifdef PUGIXML_WCHAR_MODE
-		return wcstod(string, 0);
+		return wcstod(string, nullptr);
 	#else
-		return strtod(string, 0);
+		return strtod(string, nullptr);
 	#endif
 	}
 
-	PUGI__FN bool convert_string_to_number_scratch(char_t (&buffer)[32], const char_t* begin, const char_t* end, double* out_result)
+	PUGI_IMPL_FN bool convert_string_to_number_scratch(char_t (&buffer)[32], const char_t* begin, const char_t* end, double* out_result)
 	{
 		size_t length = static_cast<size_t>(end - begin);
 		char_t* scratch = buffer;
@@ -8579,24 +8969,24 @@ PUGI__NS_BEGIN
 		return true;
 	}
 
-	PUGI__FN double round_nearest(double value)
+	PUGI_IMPL_FN double round_nearest(double value)
 	{
 		return floor(value + 0.5);
 	}
 
-	PUGI__FN double round_nearest_nzero(double value)
+	PUGI_IMPL_FN double round_nearest_nzero(double value)
 	{
 		// same as round_nearest, but returns -0 for [-0.5, -0]
 		// ceil is used to differentiate between +0 and -0 (we return -0 for [-0.5, -0] and +0 for +0)
 		return (value >= -0.5 && value <= 0) ? ceil(value) : floor(value + 0.5);
 	}
 
-	PUGI__FN const char_t* qualified_name(const xpath_node& node)
+	PUGI_IMPL_FN const char_t* qualified_name(const xpath_node& node)
 	{
 		return node.attribute() ? node.attribute().name() : node.node().name();
 	}
 
-	PUGI__FN const char_t* local_name(const xpath_node& node)
+	PUGI_IMPL_FN const char_t* local_name(const xpath_node& node)
 	{
 		const char_t* name = qualified_name(node);
 		const char_t* p = find_char(name, ':');
@@ -8613,7 +9003,7 @@ PUGI__NS_BEGIN
 		{
 			const char_t* pos = find_char(name, ':');
 
-			prefix = pos ? name : 0;
+			prefix = pos ? name : nullptr;
 			prefix_length = pos ? static_cast<size_t>(pos - name) : 0;
 		}
 
@@ -8627,7 +9017,7 @@ PUGI__NS_BEGIN
 		}
 	};
 
-	PUGI__FN const char_t* namespace_uri(xml_node node)
+	PUGI_IMPL_FN const char_t* namespace_uri(xml_node node)
 	{
 		namespace_uri_predicate pred = node.name();
 
@@ -8645,7 +9035,7 @@ PUGI__NS_BEGIN
 		return PUGIXML_TEXT("");
 	}
 
-	PUGI__FN const char_t* namespace_uri(xml_attribute attr, xml_node parent)
+	PUGI_IMPL_FN const char_t* namespace_uri(xml_attribute attr, xml_node parent)
 	{
 		namespace_uri_predicate pred = attr.name();
 
@@ -8666,12 +9056,12 @@ PUGI__NS_BEGIN
 		return PUGIXML_TEXT("");
 	}
 
-	PUGI__FN const char_t* namespace_uri(const xpath_node& node)
+	PUGI_IMPL_FN const char_t* namespace_uri(const xpath_node& node)
 	{
 		return node.attribute() ? namespace_uri(node.attribute(), node.parent()) : namespace_uri(node.node());
 	}
 
-	PUGI__FN char_t* normalize_space(char_t* buffer)
+	PUGI_IMPL_FN char_t* normalize_space(char_t* buffer)
 	{
 		char_t* write = buffer;
 
@@ -8679,10 +9069,10 @@ PUGI__NS_BEGIN
 		{
 			char_t ch = *it++;
 
-			if (PUGI__IS_CHARTYPE(ch, ct_space))
+			if (PUGI_IMPL_IS_CHARTYPE(ch, ct_space))
 			{
 				// replace whitespace sequence with single space
-				while (PUGI__IS_CHARTYPE(*it, ct_space)) it++;
+				while (PUGI_IMPL_IS_CHARTYPE(*it, ct_space)) it++;
 
 				// avoid leading spaces
 				if (write != buffer) *write++ = ' ';
@@ -8691,7 +9081,7 @@ PUGI__NS_BEGIN
 		}
 
 		// remove trailing space
-		if (write != buffer && PUGI__IS_CHARTYPE(write[-1], ct_space)) write--;
+		if (write != buffer && PUGI_IMPL_IS_CHARTYPE(write[-1], ct_space)) write--;
 
 		// zero-terminate
 		*write = 0;
@@ -8699,13 +9089,13 @@ PUGI__NS_BEGIN
 		return write;
 	}
 
-	PUGI__FN char_t* translate(char_t* buffer, const char_t* from, const char_t* to, size_t to_length)
+	PUGI_IMPL_FN char_t* translate(char_t* buffer, const char_t* from, const char_t* to, size_t to_length)
 	{
 		char_t* write = buffer;
 
 		while (*buffer)
 		{
-			PUGI__DMC_VOLATILE char_t ch = *buffer++;
+			PUGI_IMPL_DMC_VOLATILE char_t ch = *buffer++;
 
 			const char_t* pos = find_char(from, ch);
 
@@ -8721,7 +9111,7 @@ PUGI__NS_BEGIN
 		return write;
 	}
 
-	PUGI__FN unsigned char* translate_table_generate(xpath_allocator* alloc, const char_t* from, const char_t* to)
+	PUGI_IMPL_FN unsigned char* translate_table_generate(xpath_allocator* alloc, const char_t* from, const char_t* to)
 	{
 		unsigned char table[128] = {0};
 
@@ -8731,7 +9121,7 @@ PUGI__NS_BEGIN
 			unsigned int tc = static_cast<unsigned int>(*to);
 
 			if (fc >= 128 || tc >= 128)
-				return 0;
+				return nullptr;
 
 			// code=128 means "skip character"
 			if (!table[fc])
@@ -8746,14 +9136,14 @@ PUGI__NS_BEGIN
 				table[i] = static_cast<unsigned char>(i);
 
 		void* result = alloc->allocate(sizeof(table));
-		if (!result) return 0;
+		if (!result) return nullptr;
 
 		memcpy(result, table, sizeof(table));
 
 		return static_cast<unsigned char*>(result);
 	}
 
-	PUGI__FN char_t* translate_table(char_t* buffer, const unsigned char* table)
+	PUGI_IMPL_FN char_t* translate_table(char_t* buffer, const unsigned char* table)
 	{
 		char_t* write = buffer;
 
@@ -8810,7 +9200,7 @@ PUGI__NS_BEGIN
 
 	struct xpath_variable_string: xpath_variable
 	{
-		xpath_variable_string(): xpath_variable(xpath_type_string), value(0)
+		xpath_variable_string(): xpath_variable(xpath_type_string), value(nullptr)
 		{
 		}
 
@@ -8835,7 +9225,7 @@ PUGI__NS_BEGIN
 
 	static const xpath_node_set dummy_node_set;
 
-	PUGI__FN PUGI__UNSIGNED_OVERFLOW unsigned int hash_string(const char_t* str)
+	PUGI_IMPL_FN PUGI_IMPL_UNSIGNED_OVERFLOW unsigned int hash_string(const char_t* str)
 	{
 		// Jenkins one-at-a-time hash (http://en.wikipedia.org/wiki/Jenkins_hash_function#one-at-a-time)
 		unsigned int result = 0;
@@ -8854,14 +9244,14 @@ PUGI__NS_BEGIN
 		return result;
 	}
 
-	template <typename T> PUGI__FN T* new_xpath_variable(const char_t* name)
+	template <typename T> PUGI_IMPL_FN T* new_xpath_variable(const char_t* name)
 	{
 		size_t length = strlength(name);
-		if (length == 0) return 0; // empty variable names are invalid
+		if (length == 0) return nullptr; // empty variable names are invalid
 
 		// $$ we can't use offsetof(T, name) because T is non-POD, so we just allocate additional length characters
 		void* memory = xml_memory::allocate(sizeof(T) + length * sizeof(char_t));
-		if (!memory) return 0;
+		if (!memory) return nullptr;
 
 		T* result = new (memory) T();
 
@@ -8870,7 +9260,7 @@ PUGI__NS_BEGIN
 		return result;
 	}
 
-	PUGI__FN xpath_variable* new_xpath_variable(xpath_value_type type, const char_t* name)
+	PUGI_IMPL_FN xpath_variable* new_xpath_variable(xpath_value_type type, const char_t* name)
 	{
 		switch (type)
 		{
@@ -8887,17 +9277,17 @@ PUGI__NS_BEGIN
 			return new_xpath_variable<xpath_variable_boolean>(name);
 
 		default:
-			return 0;
+			return nullptr;
 		}
 	}
 
-	template <typename T> PUGI__FN void delete_xpath_variable(T* var)
+	template <typename T> PUGI_IMPL_FN void delete_xpath_variable(T* var)
 	{
 		var->~T();
 		xml_memory::deallocate(var);
 	}
 
-	PUGI__FN void delete_xpath_variable(xpath_value_type type, xpath_variable* var)
+	PUGI_IMPL_FN void delete_xpath_variable(xpath_value_type type, xpath_variable* var)
 	{
 		switch (type)
 		{
@@ -8922,7 +9312,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN bool copy_xpath_variable(xpath_variable* lhs, const xpath_variable* rhs)
+	PUGI_IMPL_FN bool copy_xpath_variable(xpath_variable* lhs, const xpath_variable* rhs)
 	{
 		switch (rhs->type())
 		{
@@ -8944,7 +9334,7 @@ PUGI__NS_BEGIN
 		}
 	}
 
-	PUGI__FN bool get_variable_scratch(char_t (&buffer)[32], xpath_variable_set* set, const char_t* begin, const char_t* end, xpath_variable** out_result)
+	PUGI_IMPL_FN bool get_variable_scratch(char_t (&buffer)[32], xpath_variable_set* set, const char_t* begin, const char_t* end, xpath_variable** out_result)
 	{
 		size_t length = static_cast<size_t>(end - begin);
 		char_t* scratch = buffer;
@@ -8967,11 +9357,11 @@ PUGI__NS_BEGIN
 
 		return true;
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 // Internal node set class
-PUGI__NS_BEGIN
-	PUGI__FN xpath_node_set::type_t xpath_get_order(const xpath_node* begin, const xpath_node* end)
+PUGI_IMPL_NS_BEGIN
+	PUGI_IMPL_FN xpath_node_set::type_t xpath_get_order(const xpath_node* begin, const xpath_node* end)
 	{
 		if (end - begin < 2)
 			return xpath_node_set::type_sorted;
@@ -8987,7 +9377,7 @@ PUGI__NS_BEGIN
 		return first ? xpath_node_set::type_sorted : xpath_node_set::type_sorted_reverse;
 	}
 
-	PUGI__FN xpath_node_set::type_t xpath_sort(xpath_node* begin, xpath_node* end, xpath_node_set::type_t type, bool rev)
+	PUGI_IMPL_FN xpath_node_set::type_t xpath_sort(xpath_node* begin, xpath_node* end, xpath_node_set::type_t type, bool rev)
 	{
 		xpath_node_set::type_t order = rev ? xpath_node_set::type_sorted_reverse : xpath_node_set::type_sorted;
 
@@ -9010,7 +9400,7 @@ PUGI__NS_BEGIN
 		return order;
 	}
 
-	PUGI__FN xpath_node xpath_first(const xpath_node* begin, const xpath_node* end, xpath_node_set::type_t type)
+	PUGI_IMPL_FN xpath_node xpath_first(const xpath_node* begin, const xpath_node* end, xpath_node_set::type_t type)
 	{
 		if (begin == end) return xpath_node();
 
@@ -9040,7 +9430,7 @@ PUGI__NS_BEGIN
 		xpath_node* _eos;
 
 	public:
-		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(0), _end(0), _eos(0)
+		xpath_node_set_raw(): _type(xpath_node_set::type_unsorted), _begin(nullptr), _end(nullptr), _eos(nullptr)
 		{
 		}
 
@@ -9164,7 +9554,7 @@ PUGI__NS_BEGIN
 		}
 	};
 
-	PUGI__FN_NO_INLINE void xpath_node_set_raw::push_back_grow(const xpath_node& node, xpath_allocator* alloc)
+	PUGI_IMPL_FN_NO_INLINE void xpath_node_set_raw::push_back_grow(const xpath_node& node, xpath_allocator* alloc)
 	{
 		size_t capacity = static_cast<size_t>(_eos - _begin);
 
@@ -9183,9 +9573,9 @@ PUGI__NS_BEGIN
 		// push
 		*_end++ = node;
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
-PUGI__NS_BEGIN
+PUGI_IMPL_NS_BEGIN
 	struct xpath_context
 	{
 		xpath_node n;
@@ -9232,7 +9622,7 @@ PUGI__NS_BEGIN
 		const char_t* begin;
 		const char_t* end;
 
-		xpath_lexer_string(): begin(0), end(0)
+		xpath_lexer_string(): begin(nullptr), end(nullptr)
 		{
 		}
 
@@ -9267,7 +9657,7 @@ PUGI__NS_BEGIN
 		{
 			const char_t* cur = _cur;
 
-			while (PUGI__IS_CHARTYPE(*cur, ct_space)) ++cur;
+			while (PUGI_IMPL_IS_CHARTYPE(*cur, ct_space)) ++cur;
 
 			// save lexeme position for error reporting
 			_cur_lexeme_pos = cur;
@@ -9349,17 +9739,17 @@ PUGI__NS_BEGIN
 			case '$':
 				cur += 1;
 
-				if (PUGI__IS_CHARTYPEX(*cur, ctx_start_symbol))
+				if (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_start_symbol))
 				{
 					_cur_lexeme_contents.begin = cur;
 
-					while (PUGI__IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
+					while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
 
-					if (cur[0] == ':' && PUGI__IS_CHARTYPEX(cur[1], ctx_symbol)) // qname
+					if (cur[0] == ':' && PUGI_IMPL_IS_CHARTYPEX(cur[1], ctx_symbol)) // qname
 					{
 						cur++; // :
 
-						while (PUGI__IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
+						while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
 					}
 
 					_cur_lexeme_contents.end = cur;
@@ -9422,13 +9812,13 @@ PUGI__NS_BEGIN
 					cur += 2;
 					_cur_lexeme = lex_double_dot;
 				}
-				else if (PUGI__IS_CHARTYPEX(*(cur+1), ctx_digit))
+				else if (PUGI_IMPL_IS_CHARTYPEX(*(cur+1), ctx_digit))
 				{
 					_cur_lexeme_contents.begin = cur; // .
 
 					++cur;
 
-					while (PUGI__IS_CHARTYPEX(*cur, ctx_digit)) cur++;
+					while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit)) cur++;
 
 					_cur_lexeme_contents.end = cur;
 
@@ -9482,28 +9872,28 @@ PUGI__NS_BEGIN
 				break;
 
 			default:
-				if (PUGI__IS_CHARTYPEX(*cur, ctx_digit))
+				if (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit))
 				{
 					_cur_lexeme_contents.begin = cur;
 
-					while (PUGI__IS_CHARTYPEX(*cur, ctx_digit)) cur++;
+					while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit)) cur++;
 
 					if (*cur == '.')
 					{
 						cur++;
 
-						while (PUGI__IS_CHARTYPEX(*cur, ctx_digit)) cur++;
+						while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_digit)) cur++;
 					}
 
 					_cur_lexeme_contents.end = cur;
 
 					_cur_lexeme = lex_number;
 				}
-				else if (PUGI__IS_CHARTYPEX(*cur, ctx_start_symbol))
+				else if (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_start_symbol))
 				{
 					_cur_lexeme_contents.begin = cur;
 
-					while (PUGI__IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
+					while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
 
 					if (cur[0] == ':')
 					{
@@ -9511,11 +9901,11 @@ PUGI__NS_BEGIN
 						{
 							cur += 2; // :*
 						}
-						else if (PUGI__IS_CHARTYPEX(cur[1], ctx_symbol)) // namespace test qname
+						else if (PUGI_IMPL_IS_CHARTYPEX(cur[1], ctx_symbol)) // namespace test qname
 						{
 							cur++; // :
 
-							while (PUGI__IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
+							while (PUGI_IMPL_IS_CHARTYPEX(*cur, ctx_symbol)) cur++;
 						}
 					}
 
@@ -9927,7 +10317,8 @@ PUGI__NS_BEGIN
 
 			xpath_node* last = ns.begin() + first;
 
-			xpath_context c(xpath_node(), 1, size);
+			xpath_node cn;
+			xpath_context c(cn, 1, size);
 
 			double er = expr->eval_number(c, stack);
 
@@ -10014,7 +10405,7 @@ PUGI__NS_BEGIN
 		{
 			assert(n);
 
-			xml_node_type type = PUGI__NODETYPE(n);
+			xml_node_type type = PUGI_IMPL_NODETYPE(n);
 
 			switch (_test)
 			{
@@ -10419,40 +10810,40 @@ PUGI__NS_BEGIN
 
 	public:
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, const char_t* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(0), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(nullptr), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_string_constant);
 			_data.string = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, double value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(0), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(nullptr), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_number_constant);
 			_data.number = value;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_variable* value):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(0), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(nullptr), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_variable);
 			_data.variable = value;
 		}
 
-		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = 0, xpath_ast_node* right = 0):
-			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(0)
+		xpath_ast_node(ast_type_t type, xpath_value_type rettype_, xpath_ast_node* left = nullptr, xpath_ast_node* right = nullptr):
+			_type(static_cast<char>(type)), _rettype(static_cast<char>(rettype_)), _axis(0), _test(0), _left(left), _right(right), _next(nullptr)
 		{
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(0), _next(0)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(static_cast<char>(axis)), _test(static_cast<char>(test)), _left(left), _right(nullptr), _next(nullptr)
 		{
 			assert(type == ast_step);
 			_data.nodetest = contents;
 		}
 
 		xpath_ast_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test):
-			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(0)
+			_type(static_cast<char>(type)), _rettype(xpath_type_node_set), _axis(0), _test(static_cast<char>(test)), _left(left), _right(right), _next(nullptr)
 		{
 			assert(type == ast_filter || type == ast_predicate);
 		}
@@ -10512,7 +10903,7 @@ PUGI__NS_BEGIN
 				xpath_string lr = _left->eval_string(c, stack);
 				xpath_string rr = _right->eval_string(c, stack);
 
-				return find_substring(lr.c_str(), rr.c_str()) != 0;
+				return find_substring(lr.c_str(), rr.c_str()) != nullptr;
 			}
 
 			case ast_func_boolean:
@@ -11321,7 +11712,7 @@ PUGI__NS_BEGIN
 			_result->error = message;
 			_result->offset = _lexer.current_pos() - _query;
 
-			return 0;
+			return nullptr;
 		}
 
 		xpath_ast_node* error_oom()
@@ -11329,7 +11720,7 @@ PUGI__NS_BEGIN
 			assert(_alloc->_error);
 			*_alloc->_error = true;
 
-			return 0;
+			return nullptr;
 		}
 
 		xpath_ast_node* error_rec()
@@ -11345,37 +11736,37 @@ PUGI__NS_BEGIN
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, const char_t* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, double value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_variable* value)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, value) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, value) : nullptr;
 		}
 
-		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = 0, xpath_ast_node* right = 0)
+		xpath_ast_node* alloc_node(ast_type_t type, xpath_value_type rettype, xpath_ast_node* left = nullptr, xpath_ast_node* right = nullptr)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : 0;
+			return memory ? new (memory) xpath_ast_node(type, rettype, left, right) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, axis_t axis, nodetest_t test, const char_t* contents)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : 0;
+			return memory ? new (memory) xpath_ast_node(type, left, axis, test, contents) : nullptr;
 		}
 
 		xpath_ast_node* alloc_node(ast_type_t type, xpath_ast_node* left, xpath_ast_node* right, predicate_t test)
 		{
 			void* memory = alloc_node();
-			return memory ? new (memory) xpath_ast_node(type, left, right, test) : 0;
+			return memory ? new (memory) xpath_ast_node(type, left, right, test) : nullptr;
 		}
 
 		const char_t* alloc_string(const xpath_lexer_string& value)
@@ -11386,7 +11777,7 @@ PUGI__NS_BEGIN
 			size_t length = static_cast<size_t>(value.end - value.begin);
 
 			char_t* c = static_cast<char_t*>(_alloc->allocate((length + 1) * sizeof(char_t)));
-			if (!c) return 0;
+			if (!c) return nullptr;
 
 			memcpy(c, value.begin, length * sizeof(char_t));
 			c[length] = 0;
@@ -11629,7 +12020,7 @@ PUGI__NS_BEGIN
 				if (!_variables)
 					return error("Unknown variable: variable set is not provided");
 
-				xpath_variable* var = 0;
+				xpath_variable* var = nullptr;
 				if (!get_variable_scratch(_scratch, _variables, name.begin, name.end, &var))
 					return error_oom();
 
@@ -11646,7 +12037,7 @@ PUGI__NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = parse_expression();
-				if (!n) return 0;
+				if (!n) return NULL;
 
 				if (_lexer.current() != lex_close_brace)
 					return error("Expected ')' to match an opening '('");
@@ -11659,7 +12050,7 @@ PUGI__NS_BEGIN
 			case lex_quoted_string:
 			{
 				const char_t* value = alloc_string(_lexer.contents());
-				if (!value) return 0;
+				if (!value) return nullptr;
 
 				_lexer.next();
 
@@ -11680,13 +12071,13 @@ PUGI__NS_BEGIN
 
 			case lex_string:
 			{
-				xpath_ast_node* args[2] = {0};
+				xpath_ast_node* args[2] = {nullptr};
 				size_t argc = 0;
 
 				xpath_lexer_string function = _lexer.contents();
 				_lexer.next();
 
-				xpath_ast_node* last_arg = 0;
+				xpath_ast_node* last_arg = nullptr;
 
 				if (_lexer.current() != lex_open_brace)
 					return error("Unrecognized function call");
@@ -11707,7 +12098,7 @@ PUGI__NS_BEGIN
 						return error_rec();
 
 					xpath_ast_node* n = parse_expression();
-					if (!n) return 0;
+					if (!n) return nullptr;
 
 					if (argc < 2) args[argc] = n;
 					else last_arg->set_next(n);
@@ -11734,7 +12125,7 @@ PUGI__NS_BEGIN
 		xpath_ast_node* parse_filter_expression()
 		{
 			xpath_ast_node* n = parse_primary_expression();
-			if (!n) return 0;
+			if (!n) return nullptr;
 
 			size_t old_depth = _depth;
 
@@ -11749,10 +12140,10 @@ PUGI__NS_BEGIN
 					return error("Predicate has to be applied to node set");
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return 0;
+				if (!expr) return nullptr;
 
 				n = alloc_node(ast_filter, n, expr, predicate_default);
-				if (!n) return 0;
+				if (!n) return nullptr;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -11792,7 +12183,7 @@ PUGI__NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_self, nodetest_type_node, 0);
+				return alloc_node(ast_step, set, axis_self, nodetest_type_node, nullptr);
 			}
 			else if (_lexer.current() == lex_double_dot)
 			{
@@ -11801,7 +12192,7 @@ PUGI__NS_BEGIN
 				if (_lexer.current() == lex_open_square_brace)
 					return error("Predicates are not allowed after an abbreviated step");
 
-				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, 0);
+				return alloc_node(ast_step, set, axis_parent, nodetest_type_node, nullptr);
 			}
 
 			nodetest_t nt_type = nodetest_none;
@@ -11908,14 +12299,14 @@ PUGI__NS_BEGIN
 			}
 
 			const char_t* nt_name_copy = alloc_string(nt_name);
-			if (!nt_name_copy) return 0;
+			if (!nt_name_copy) return nullptr;
 
 			xpath_ast_node* n = alloc_node(ast_step, set, axis, nt_type, nt_name_copy);
-			if (!n) return 0;
+			if (!n) return nullptr;
 
 			size_t old_depth = _depth;
 
-			xpath_ast_node* last = 0;
+			xpath_ast_node* last = nullptr;
 
 			while (_lexer.current() == lex_open_square_brace)
 			{
@@ -11925,10 +12316,10 @@ PUGI__NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* expr = parse_expression();
-				if (!expr) return 0;
+				if (!expr) return nullptr;
 
-				xpath_ast_node* pred = alloc_node(ast_predicate, 0, expr, predicate_default);
-				if (!pred) return 0;
+				xpath_ast_node* pred = alloc_node(ast_predicate, nullptr, expr, predicate_default);
+				if (!pred) return nullptr;
 
 				if (_lexer.current() != lex_close_square_brace)
 					return error("Expected ']' to match an opening '['");
@@ -11949,7 +12340,7 @@ PUGI__NS_BEGIN
 		xpath_ast_node* parse_relative_location_path(xpath_ast_node* set)
 		{
 			xpath_ast_node* n = parse_step(set);
-			if (!n) return 0;
+			if (!n) return nullptr;
 
 			size_t old_depth = _depth;
 
@@ -11960,8 +12351,8 @@ PUGI__NS_BEGIN
 
 				if (l == lex_double_slash)
 				{
-					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
-					if (!n) return 0;
+					n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, nullptr);
+					if (!n) return nullptr;
 
 					++_depth;
 				}
@@ -11970,7 +12361,7 @@ PUGI__NS_BEGIN
 					return error_rec();
 
 				n = parse_step(n);
-				if (!n) return 0;
+				if (!n) return nullptr;
 			}
 
 			_depth = old_depth;
@@ -11987,7 +12378,7 @@ PUGI__NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return 0;
+				if (!n) return nullptr;
 
 				// relative location path can start from axis_attribute, dot, double_dot, multiply and string lexemes; any other lexeme means standalone root path
 				lexeme_t l = _lexer.current();
@@ -12002,16 +12393,16 @@ PUGI__NS_BEGIN
 				_lexer.next();
 
 				xpath_ast_node* n = alloc_node(ast_step_root, xpath_type_node_set);
-				if (!n) return 0;
+				if (!n) return nullptr;
 
-				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
-				if (!n) return 0;
+				n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, nullptr);
+				if (!n) return nullptr;
 
 				return parse_relative_location_path(n);
 			}
 
 			// else clause moved outside of if because of bogus warning 'control may reach end of non-void function being inlined' in gcc 4.0.1
-			return parse_relative_location_path(0);
+			return parse_relative_location_path(nullptr);
 		}
 
 		// PathExpr ::= LocationPath
@@ -12037,7 +12428,7 @@ PUGI__NS_BEGIN
 					// This is either a function call, or not - if not, we shall proceed with location path
 					const char_t* state = _lexer.state();
 
-					while (PUGI__IS_CHARTYPE(*state, ct_space)) ++state;
+					while (PUGI_IMPL_IS_CHARTYPE(*state, ct_space)) ++state;
 
 					if (*state != '(')
 						return parse_location_path();
@@ -12048,7 +12439,7 @@ PUGI__NS_BEGIN
 				}
 
 				xpath_ast_node* n = parse_filter_expression();
-				if (!n) return 0;
+				if (!n) return nullptr;
 
 				if (_lexer.current() == lex_slash || _lexer.current() == lex_double_slash)
 				{
@@ -12060,8 +12451,8 @@ PUGI__NS_BEGIN
 						if (n->rettype() != xpath_type_node_set)
 							return error("Step has to be applied to node set");
 
-						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, 0);
-						if (!n) return 0;
+						n = alloc_node(ast_step, n, axis_descendant_or_self, nodetest_type_node, nullptr);
+						if (!n) return nullptr;
 					}
 
 					// select from location path
@@ -12076,7 +12467,7 @@ PUGI__NS_BEGIN
 
 				// precedence 7+ - only parses union expressions
 				xpath_ast_node* n = parse_expression(7);
-				if (!n) return 0;
+				if (!n) return nullptr;
 
 				return alloc_node(ast_op_negate, xpath_type_number, n);
 			}
@@ -12164,14 +12555,14 @@ PUGI__NS_BEGIN
 					return error_rec();
 
 				xpath_ast_node* rhs = parse_path_or_unary_expression();
-				if (!rhs) return 0;
+				if (!rhs) return nullptr;
 
 				binary_op_t nextop = binary_op_t::parse(_lexer);
 
 				while (nextop.asttype != ast_unknown && nextop.precedence > op.precedence)
 				{
 					rhs = parse_expression_rec(rhs, nextop.precedence);
-					if (!rhs) return 0;
+					if (!rhs) return nullptr;
 
 					nextop = binary_op_t::parse(_lexer);
 				}
@@ -12180,7 +12571,7 @@ PUGI__NS_BEGIN
 					return error("Union operator has to be applied to node sets");
 
 				lhs = alloc_node(op.asttype, op.rettype, lhs, rhs);
-				if (!lhs) return 0;
+				if (!lhs) return nullptr;
 
 				op = binary_op_t::parse(_lexer);
 			}
@@ -12214,7 +12605,7 @@ PUGI__NS_BEGIN
 				return error_rec();
 
 			xpath_ast_node* n = parse_path_or_unary_expression();
-			if (!n) return 0;
+			if (!n) return nullptr;
 
 			n = parse_expression_rec(n, limit);
 
@@ -12230,7 +12621,7 @@ PUGI__NS_BEGIN
 		xpath_ast_node* parse()
 		{
 			xpath_ast_node* n = parse_expression();
-			if (!n) return 0;
+			if (!n) return nullptr;
 
 			assert(_depth == 0);
 
@@ -12254,7 +12645,7 @@ PUGI__NS_BEGIN
 		static xpath_query_impl* create()
 		{
 			void* memory = xml_memory::allocate(sizeof(xpath_query_impl));
-			if (!memory) return 0;
+			if (!memory) return nullptr;
 
 			return new (memory) xpath_query_impl();
 		}
@@ -12268,9 +12659,9 @@ PUGI__NS_BEGIN
 			xml_memory::deallocate(impl);
 		}
 
-		xpath_query_impl(): root(0), alloc(&block, &oom), oom(false)
+		xpath_query_impl(): root(nullptr), alloc(&block, &oom), oom(false)
 		{
-			block.next = 0;
+			block.next = nullptr;
 			block.capacity = sizeof(block.data);
 		}
 
@@ -12280,9 +12671,9 @@ PUGI__NS_BEGIN
 		bool oom;
 	};
 
-	PUGI__FN impl::xpath_ast_node* evaluate_node_set_prepare(xpath_query_impl* impl)
+	PUGI_IMPL_FN impl::xpath_ast_node* evaluate_node_set_prepare(xpath_query_impl* impl)
 	{
-		if (!impl) return 0;
+		if (!impl) return nullptr;
 
 		if (impl->root->rettype() != xpath_type_node_set)
 		{
@@ -12298,91 +12689,91 @@ PUGI__NS_BEGIN
 
 		return impl->root;
 	}
-PUGI__NS_END
+PUGI_IMPL_NS_END
 
 namespace pugi
 {
 #ifndef PUGIXML_NO_EXCEPTIONS
-	PUGI__FN xpath_exception::xpath_exception(const xpath_parse_result& result_): _result(result_)
+	PUGI_IMPL_FN xpath_exception::xpath_exception(const xpath_parse_result& result_): _result(result_)
 	{
 		assert(_result.error);
 	}
 
-	PUGI__FN const char* xpath_exception::what() const throw()
+	PUGI_IMPL_FN const char* xpath_exception::what() const PUGIXML_NOEXCEPT
 	{
 		return _result.error;
 	}
 
-	PUGI__FN const xpath_parse_result& xpath_exception::result() const
+	PUGI_IMPL_FN const xpath_parse_result& xpath_exception::result() const
 	{
 		return _result;
 	}
 #endif
 
-	PUGI__FN xpath_node::xpath_node()
+	PUGI_IMPL_FN xpath_node::xpath_node()
 	{
 	}
 
-	PUGI__FN xpath_node::xpath_node(const xml_node& node_): _node(node_)
+	PUGI_IMPL_FN xpath_node::xpath_node(const xml_node& node_): _node(node_)
 	{
 	}
 
-	PUGI__FN xpath_node::xpath_node(const xml_attribute& attribute_, const xml_node& parent_): _node(attribute_ ? parent_ : xml_node()), _attribute(attribute_)
+	PUGI_IMPL_FN xpath_node::xpath_node(const xml_attribute& attribute_, const xml_node& parent_): _node(attribute_ ? parent_ : xml_node()), _attribute(attribute_)
 	{
 	}
 
-	PUGI__FN xml_node xpath_node::node() const
+	PUGI_IMPL_FN xml_node xpath_node::node() const
 	{
 		return _attribute ? xml_node() : _node;
 	}
 
-	PUGI__FN xml_attribute xpath_node::attribute() const
+	PUGI_IMPL_FN xml_attribute xpath_node::attribute() const
 	{
 		return _attribute;
 	}
 
-	PUGI__FN xml_node xpath_node::parent() const
+	PUGI_IMPL_FN xml_node xpath_node::parent() const
 	{
 		return _attribute ? _node : _node.parent();
 	}
 
-	PUGI__FN static void unspecified_bool_xpath_node(xpath_node***)
+	PUGI_IMPL_FN static void unspecified_bool_xpath_node(xpath_node***)
 	{
 	}
 
-	PUGI__FN xpath_node::operator xpath_node::unspecified_bool_type() const
+	PUGI_IMPL_FN xpath_node::operator xpath_node::unspecified_bool_type() const
 	{
-		return (_node || _attribute) ? unspecified_bool_xpath_node : 0;
+		return (_node || _attribute) ? unspecified_bool_xpath_node : nullptr;
 	}
 
-	PUGI__FN bool xpath_node::operator!() const
+	PUGI_IMPL_FN bool xpath_node::operator!() const
 	{
 		return !(_node || _attribute);
 	}
 
-	PUGI__FN bool xpath_node::operator==(const xpath_node& n) const
+	PUGI_IMPL_FN bool xpath_node::operator==(const xpath_node& n) const
 	{
 		return _node == n._node && _attribute == n._attribute;
 	}
 
-	PUGI__FN bool xpath_node::operator!=(const xpath_node& n) const
+	PUGI_IMPL_FN bool xpath_node::operator!=(const xpath_node& n) const
 	{
 		return _node != n._node || _attribute != n._attribute;
 	}
 
 #ifdef __BORLANDC__
-	PUGI__FN bool operator&&(const xpath_node& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator&&(const xpath_node& lhs, bool rhs)
 	{
 		return (bool)lhs && rhs;
 	}
 
-	PUGI__FN bool operator||(const xpath_node& lhs, bool rhs)
+	PUGI_IMPL_FN bool operator||(const xpath_node& lhs, bool rhs)
 	{
 		return (bool)lhs || rhs;
 	}
 #endif
 
-	PUGI__FN void xpath_node_set::_assign(const_iterator begin_, const_iterator end_, type_t type_)
+	PUGI_IMPL_FN void xpath_node_set::_assign(const_iterator begin_, const_iterator end_, type_t type_)
 	{
 		assert(begin_ <= end_);
 
@@ -12414,7 +12805,7 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN void xpath_node_set::_move(xpath_node_set& rhs) PUGIXML_NOEXCEPT
+	PUGI_IMPL_FN void xpath_node_set::_move(xpath_node_set& rhs) PUGIXML_NOEXCEPT
 	{
 		_type = rhs._type;
 		_storage[0] = rhs._storage[0];
@@ -12427,27 +12818,27 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xpath_node_set::xpath_node_set(): _type(type_unsorted), _begin(_storage), _end(_storage)
+	PUGI_IMPL_FN xpath_node_set::xpath_node_set(): _type(type_unsorted), _begin(_storage), _end(_storage)
 	{
 	}
 
-	PUGI__FN xpath_node_set::xpath_node_set(const_iterator begin_, const_iterator end_, type_t type_): _type(type_unsorted), _begin(_storage), _end(_storage)
+	PUGI_IMPL_FN xpath_node_set::xpath_node_set(const_iterator begin_, const_iterator end_, type_t type_): _type(type_unsorted), _begin(_storage), _end(_storage)
 	{
 		_assign(begin_, end_, type_);
 	}
 
-	PUGI__FN xpath_node_set::~xpath_node_set()
+	PUGI_IMPL_FN xpath_node_set::~xpath_node_set()
 	{
 		if (_begin != _storage)
 			impl::xml_memory::deallocate(_begin);
 	}
 
-	PUGI__FN xpath_node_set::xpath_node_set(const xpath_node_set& ns): _type(type_unsorted), _begin(_storage), _end(_storage)
+	PUGI_IMPL_FN xpath_node_set::xpath_node_set(const xpath_node_set& ns): _type(type_unsorted), _begin(_storage), _end(_storage)
 	{
 		_assign(ns._begin, ns._end, ns._type);
 	}
 
-	PUGI__FN xpath_node_set& xpath_node_set::operator=(const xpath_node_set& ns)
+	PUGI_IMPL_FN xpath_node_set& xpath_node_set::operator=(const xpath_node_set& ns)
 	{
 		if (this == &ns) return *this;
 
@@ -12457,12 +12848,12 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xpath_node_set::xpath_node_set(xpath_node_set&& rhs) PUGIXML_NOEXCEPT: _type(type_unsorted), _begin(_storage), _end(_storage)
+	PUGI_IMPL_FN xpath_node_set::xpath_node_set(xpath_node_set&& rhs) PUGIXML_NOEXCEPT: _type(type_unsorted), _begin(_storage), _end(_storage)
 	{
 		_move(rhs);
 	}
 
-	PUGI__FN xpath_node_set& xpath_node_set::operator=(xpath_node_set&& rhs) PUGIXML_NOEXCEPT
+	PUGI_IMPL_FN xpath_node_set& xpath_node_set::operator=(xpath_node_set&& rhs) PUGIXML_NOEXCEPT
 	{
 		if (this == &rhs) return *this;
 
@@ -12475,66 +12866,66 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN xpath_node_set::type_t xpath_node_set::type() const
+	PUGI_IMPL_FN xpath_node_set::type_t xpath_node_set::type() const
 	{
 		return _type;
 	}
 
-	PUGI__FN size_t xpath_node_set::size() const
+	PUGI_IMPL_FN size_t xpath_node_set::size() const
 	{
 		return _end - _begin;
 	}
 
-	PUGI__FN bool xpath_node_set::empty() const
+	PUGI_IMPL_FN bool xpath_node_set::empty() const
 	{
 		return _begin == _end;
 	}
 
-	PUGI__FN const xpath_node& xpath_node_set::operator[](size_t index) const
+	PUGI_IMPL_FN const xpath_node& xpath_node_set::operator[](size_t index) const
 	{
 		assert(index < size());
 		return _begin[index];
 	}
 
-	PUGI__FN xpath_node_set::const_iterator xpath_node_set::begin() const
+	PUGI_IMPL_FN xpath_node_set::const_iterator xpath_node_set::begin() const
 	{
 		return _begin;
 	}
 
-	PUGI__FN xpath_node_set::const_iterator xpath_node_set::end() const
+	PUGI_IMPL_FN xpath_node_set::const_iterator xpath_node_set::end() const
 	{
 		return _end;
 	}
 
-	PUGI__FN void xpath_node_set::sort(bool reverse)
+	PUGI_IMPL_FN void xpath_node_set::sort(bool reverse)
 	{
 		_type = impl::xpath_sort(_begin, _end, _type, reverse);
 	}
 
-	PUGI__FN xpath_node xpath_node_set::first() const
+	PUGI_IMPL_FN xpath_node xpath_node_set::first() const
 	{
 		return impl::xpath_first(_begin, _end, _type);
 	}
 
-	PUGI__FN xpath_parse_result::xpath_parse_result(): error("Internal error"), offset(0)
+	PUGI_IMPL_FN xpath_parse_result::xpath_parse_result(): error("Internal error"), offset(0)
 	{
 	}
 
-	PUGI__FN xpath_parse_result::operator bool() const
+	PUGI_IMPL_FN xpath_parse_result::operator bool() const
 	{
-		return error == 0;
+		return error == nullptr;
 	}
 
-	PUGI__FN const char* xpath_parse_result::description() const
+	PUGI_IMPL_FN const char* xpath_parse_result::description() const
 	{
 		return error ? error : "No error";
 	}
 
-	PUGI__FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(0)
+	PUGI_IMPL_FN xpath_variable::xpath_variable(xpath_value_type type_): _type(type_), _next(nullptr)
 	{
 	}
 
-	PUGI__FN const char_t* xpath_variable::name() const
+	PUGI_IMPL_FN const char_t* xpath_variable::name() const
 	{
 		switch (_type)
 		{
@@ -12552,37 +12943,37 @@ namespace pugi
 
 		default:
 			assert(false && "Invalid variable type"); // unreachable
-			return 0;
+			return nullptr;
 		}
 	}
 
-	PUGI__FN xpath_value_type xpath_variable::type() const
+	PUGI_IMPL_FN xpath_value_type xpath_variable::type() const
 	{
 		return _type;
 	}
 
-	PUGI__FN bool xpath_variable::get_boolean() const
+	PUGI_IMPL_FN bool xpath_variable::get_boolean() const
 	{
 		return (_type == xpath_type_boolean) ? static_cast<const impl::xpath_variable_boolean*>(this)->value : false;
 	}
 
-	PUGI__FN double xpath_variable::get_number() const
+	PUGI_IMPL_FN double xpath_variable::get_number() const
 	{
 		return (_type == xpath_type_number) ? static_cast<const impl::xpath_variable_number*>(this)->value : impl::gen_nan();
 	}
 
-	PUGI__FN const char_t* xpath_variable::get_string() const
+	PUGI_IMPL_FN const char_t* xpath_variable::get_string() const
 	{
-		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : 0;
+		const char_t* value = (_type == xpath_type_string) ? static_cast<const impl::xpath_variable_string*>(this)->value : nullptr;
 		return value ? value : PUGIXML_TEXT("");
 	}
 
-	PUGI__FN const xpath_node_set& xpath_variable::get_node_set() const
+	PUGI_IMPL_FN const xpath_node_set& xpath_variable::get_node_set() const
 	{
 		return (_type == xpath_type_node_set) ? static_cast<const impl::xpath_variable_node_set*>(this)->value : impl::dummy_node_set;
 	}
 
-	PUGI__FN bool xpath_variable::set(bool value)
+	PUGI_IMPL_FN bool xpath_variable::set(bool value)
 	{
 		if (_type != xpath_type_boolean) return false;
 
@@ -12590,7 +12981,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN bool xpath_variable::set(double value)
+	PUGI_IMPL_FN bool xpath_variable::set(double value)
 	{
 		if (_type != xpath_type_number) return false;
 
@@ -12598,7 +12989,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN bool xpath_variable::set(const char_t* value)
+	PUGI_IMPL_FN bool xpath_variable::set(const char_t* value)
 	{
 		if (_type != xpath_type_string) return false;
 
@@ -12619,7 +13010,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN bool xpath_variable::set(const xpath_node_set& value)
+	PUGI_IMPL_FN bool xpath_variable::set(const xpath_node_set& value)
 	{
 		if (_type != xpath_type_node_set) return false;
 
@@ -12627,27 +13018,27 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN xpath_variable_set::xpath_variable_set()
+	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set()
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = 0;
+			_data[i] = nullptr;
 	}
 
-	PUGI__FN xpath_variable_set::~xpath_variable_set()
+	PUGI_IMPL_FN xpath_variable_set::~xpath_variable_set()
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 			_destroy(_data[i]);
 	}
 
-	PUGI__FN xpath_variable_set::xpath_variable_set(const xpath_variable_set& rhs)
+	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set(const xpath_variable_set& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
-			_data[i] = 0;
+			_data[i] = nullptr;
 
 		_assign(rhs);
 	}
 
-	PUGI__FN xpath_variable_set& xpath_variable_set::operator=(const xpath_variable_set& rhs)
+	PUGI_IMPL_FN xpath_variable_set& xpath_variable_set::operator=(const xpath_variable_set& rhs)
 	{
 		if (this == &rhs) return *this;
 
@@ -12657,30 +13048,30 @@ namespace pugi
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xpath_variable_set::xpath_variable_set(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT
+	PUGI_IMPL_FN xpath_variable_set::xpath_variable_set(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
 			_data[i] = rhs._data[i];
-			rhs._data[i] = 0;
+			rhs._data[i] = nullptr;
 		}
 	}
 
-	PUGI__FN xpath_variable_set& xpath_variable_set::operator=(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT
+	PUGI_IMPL_FN xpath_variable_set& xpath_variable_set::operator=(xpath_variable_set&& rhs) PUGIXML_NOEXCEPT
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
 			_destroy(_data[i]);
 
 			_data[i] = rhs._data[i];
-			rhs._data[i] = 0;
+			rhs._data[i] = nullptr;
 		}
 
 		return *this;
 	}
 #endif
 
-	PUGI__FN void xpath_variable_set::_assign(const xpath_variable_set& rhs)
+	PUGI_IMPL_FN void xpath_variable_set::_assign(const xpath_variable_set& rhs)
 	{
 		xpath_variable_set temp;
 
@@ -12691,7 +13082,7 @@ namespace pugi
 		_swap(temp);
 	}
 
-	PUGI__FN void xpath_variable_set::_swap(xpath_variable_set& rhs)
+	PUGI_IMPL_FN void xpath_variable_set::_swap(xpath_variable_set& rhs)
 	{
 		for (size_t i = 0; i < sizeof(_data) / sizeof(_data[0]); ++i)
 		{
@@ -12702,7 +13093,7 @@ namespace pugi
 		}
 	}
 
-	PUGI__FN xpath_variable* xpath_variable_set::_find(const char_t* name) const
+	PUGI_IMPL_FN xpath_variable* xpath_variable_set::_find(const char_t* name) const
 	{
 		const size_t hash_size = sizeof(_data) / sizeof(_data[0]);
 		size_t hash = impl::hash_string(name) % hash_size;
@@ -12712,12 +13103,12 @@ namespace pugi
 			if (impl::strequal(var->name(), name))
 				return var;
 
-		return 0;
+		return nullptr;
 	}
 
-	PUGI__FN bool xpath_variable_set::_clone(xpath_variable* var, xpath_variable** out_result)
+	PUGI_IMPL_FN bool xpath_variable_set::_clone(xpath_variable* var, xpath_variable** out_result)
 	{
-		xpath_variable* last = 0;
+		xpath_variable* last = nullptr;
 
 		while (var)
 		{
@@ -12742,7 +13133,7 @@ namespace pugi
 		return true;
 	}
 
-	PUGI__FN void xpath_variable_set::_destroy(xpath_variable* var)
+	PUGI_IMPL_FN void xpath_variable_set::_destroy(xpath_variable* var)
 	{
 		while (var)
 		{
@@ -12754,7 +13145,7 @@ namespace pugi
 		}
 	}
 
-	PUGI__FN xpath_variable* xpath_variable_set::add(const char_t* name, xpath_value_type type)
+	PUGI_IMPL_FN xpath_variable* xpath_variable_set::add(const char_t* name, xpath_value_type type)
 	{
 		const size_t hash_size = sizeof(_data) / sizeof(_data[0]);
 		size_t hash = impl::hash_string(name) % hash_size;
@@ -12762,7 +13153,7 @@ namespace pugi
 		// look for existing variable
 		for (xpath_variable* var = _data[hash]; var; var = var->_next)
 			if (impl::strequal(var->name(), name))
-				return var->type() == type ? var : 0;
+				return var->type() == type ? var : nullptr;
 
 		// add new variable
 		xpath_variable* result = impl::new_xpath_variable(type, name);
@@ -12777,41 +13168,41 @@ namespace pugi
 		return result;
 	}
 
-	PUGI__FN bool xpath_variable_set::set(const char_t* name, bool value)
+	PUGI_IMPL_FN bool xpath_variable_set::set(const char_t* name, bool value)
 	{
 		xpath_variable* var = add(name, xpath_type_boolean);
 		return var ? var->set(value) : false;
 	}
 
-	PUGI__FN bool xpath_variable_set::set(const char_t* name, double value)
+	PUGI_IMPL_FN bool xpath_variable_set::set(const char_t* name, double value)
 	{
 		xpath_variable* var = add(name, xpath_type_number);
 		return var ? var->set(value) : false;
 	}
 
-	PUGI__FN bool xpath_variable_set::set(const char_t* name, const char_t* value)
+	PUGI_IMPL_FN bool xpath_variable_set::set(const char_t* name, const char_t* value)
 	{
 		xpath_variable* var = add(name, xpath_type_string);
 		return var ? var->set(value) : false;
 	}
 
-	PUGI__FN bool xpath_variable_set::set(const char_t* name, const xpath_node_set& value)
+	PUGI_IMPL_FN bool xpath_variable_set::set(const char_t* name, const xpath_node_set& value)
 	{
 		xpath_variable* var = add(name, xpath_type_node_set);
 		return var ? var->set(value) : false;
 	}
 
-	PUGI__FN xpath_variable* xpath_variable_set::get(const char_t* name)
+	PUGI_IMPL_FN xpath_variable* xpath_variable_set::get(const char_t* name)
 	{
 		return _find(name);
 	}
 
-	PUGI__FN const xpath_variable* xpath_variable_set::get(const char_t* name) const
+	PUGI_IMPL_FN const xpath_variable* xpath_variable_set::get(const char_t* name) const
 	{
 		return _find(name);
 	}
 
-	PUGI__FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(0)
+	PUGI_IMPL_FN xpath_query::xpath_query(const char_t* query, xpath_variable_set* variables): _impl(nullptr)
 	{
 		impl::xpath_query_impl* qimpl = impl::xpath_query_impl::create();
 
@@ -12835,7 +13226,7 @@ namespace pugi
 				qimpl->root->optimize(&qimpl->alloc);
 
 				_impl = impl.release();
-				_result.error = 0;
+				_result.error = nullptr;
 			}
 			else
 			{
@@ -12849,26 +13240,26 @@ namespace pugi
 		}
 	}
 
-	PUGI__FN xpath_query::xpath_query(): _impl(0)
+	PUGI_IMPL_FN xpath_query::xpath_query(): _impl(nullptr)
 	{
 	}
 
-	PUGI__FN xpath_query::~xpath_query()
+	PUGI_IMPL_FN xpath_query::~xpath_query()
 	{
 		if (_impl)
 			impl::xpath_query_impl::destroy(static_cast<impl::xpath_query_impl*>(_impl));
 	}
 
 #ifdef PUGIXML_HAS_MOVE
-	PUGI__FN xpath_query::xpath_query(xpath_query&& rhs) PUGIXML_NOEXCEPT
+	PUGI_IMPL_FN xpath_query::xpath_query(xpath_query&& rhs) PUGIXML_NOEXCEPT
 	{
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = 0;
+		rhs._impl = nullptr;
 		rhs._result = xpath_parse_result();
 	}
 
-	PUGI__FN xpath_query& xpath_query::operator=(xpath_query&& rhs) PUGIXML_NOEXCEPT
+	PUGI_IMPL_FN xpath_query& xpath_query::operator=(xpath_query&& rhs) PUGIXML_NOEXCEPT
 	{
 		if (this == &rhs) return *this;
 
@@ -12877,21 +13268,21 @@ namespace pugi
 
 		_impl = rhs._impl;
 		_result = rhs._result;
-		rhs._impl = 0;
+		rhs._impl = nullptr;
 		rhs._result = xpath_parse_result();
 
 		return *this;
 	}
 #endif
 
-	PUGI__FN xpath_value_type xpath_query::return_type() const
+	PUGI_IMPL_FN xpath_value_type xpath_query::return_type() const
 	{
 		if (!_impl) return xpath_type_none;
 
 		return static_cast<impl::xpath_query_impl*>(_impl)->root->rettype();
 	}
 
-	PUGI__FN bool xpath_query::evaluate_boolean(const xpath_node& n) const
+	PUGI_IMPL_FN bool xpath_query::evaluate_boolean(const xpath_node& n) const
 	{
 		if (!_impl) return false;
 
@@ -12912,7 +13303,7 @@ namespace pugi
 		return r;
 	}
 
-	PUGI__FN double xpath_query::evaluate_number(const xpath_node& n) const
+	PUGI_IMPL_FN double xpath_query::evaluate_number(const xpath_node& n) const
 	{
 		if (!_impl) return impl::gen_nan();
 
@@ -12934,7 +13325,7 @@ namespace pugi
 	}
 
 #ifndef PUGIXML_NO_STL
-	PUGI__FN string_t xpath_query::evaluate_string(const xpath_node& n) const
+	PUGI_IMPL_FN string_t xpath_query::evaluate_string(const xpath_node& n) const
 	{
 		if (!_impl) return string_t();
 
@@ -12956,7 +13347,7 @@ namespace pugi
 	}
 #endif
 
-	PUGI__FN size_t xpath_query::evaluate_string(char_t* buffer, size_t capacity, const xpath_node& n) const
+	PUGI_IMPL_FN size_t xpath_query::evaluate_string(char_t* buffer, size_t capacity, const xpath_node& n) const
 	{
 		impl::xpath_context c(n, 1, 1);
 		impl::xpath_stack_data sd;
@@ -12986,7 +13377,7 @@ namespace pugi
 		return full_size;
 	}
 
-	PUGI__FN xpath_node_set xpath_query::evaluate_node_set(const xpath_node& n) const
+	PUGI_IMPL_FN xpath_node_set xpath_query::evaluate_node_set(const xpath_node& n) const
 	{
 		impl::xpath_ast_node* root = impl::evaluate_node_set_prepare(static_cast<impl::xpath_query_impl*>(_impl));
 		if (!root) return xpath_node_set();
@@ -13008,7 +13399,7 @@ namespace pugi
 		return xpath_node_set(r.begin(), r.end(), r.type());
 	}
 
-	PUGI__FN xpath_node xpath_query::evaluate_node(const xpath_node& n) const
+	PUGI_IMPL_FN xpath_node xpath_query::evaluate_node(const xpath_node& n) const
 	{
 		impl::xpath_ast_node* root = impl::evaluate_node_set_prepare(static_cast<impl::xpath_query_impl*>(_impl));
 		if (!root) return xpath_node();
@@ -13030,54 +13421,54 @@ namespace pugi
 		return r.first();
 	}
 
-	PUGI__FN const xpath_parse_result& xpath_query::result() const
+	PUGI_IMPL_FN const xpath_parse_result& xpath_query::result() const
 	{
 		return _result;
 	}
 
-	PUGI__FN static void unspecified_bool_xpath_query(xpath_query***)
+	PUGI_IMPL_FN static void unspecified_bool_xpath_query(xpath_query***)
 	{
 	}
 
-	PUGI__FN xpath_query::operator xpath_query::unspecified_bool_type() const
+	PUGI_IMPL_FN xpath_query::operator xpath_query::unspecified_bool_type() const
 	{
-		return _impl ? unspecified_bool_xpath_query : 0;
+		return _impl ? unspecified_bool_xpath_query : nullptr;
 	}
 
-	PUGI__FN bool xpath_query::operator!() const
+	PUGI_IMPL_FN bool xpath_query::operator!() const
 	{
 		return !_impl;
 	}
 
-	PUGI__FN xpath_node xml_node::select_node(const char_t* query, xpath_variable_set* variables) const
+	PUGI_IMPL_FN xpath_node xml_node::select_node(const char_t* query, xpath_variable_set* variables) const
 	{
 		xpath_query q(query, variables);
 		return q.evaluate_node(*this);
 	}
 
-	PUGI__FN xpath_node xml_node::select_node(const xpath_query& query) const
+	PUGI_IMPL_FN xpath_node xml_node::select_node(const xpath_query& query) const
 	{
 		return query.evaluate_node(*this);
 	}
 
-	PUGI__FN xpath_node_set xml_node::select_nodes(const char_t* query, xpath_variable_set* variables) const
+	PUGI_IMPL_FN xpath_node_set xml_node::select_nodes(const char_t* query, xpath_variable_set* variables) const
 	{
 		xpath_query q(query, variables);
 		return q.evaluate_node_set(*this);
 	}
 
-	PUGI__FN xpath_node_set xml_node::select_nodes(const xpath_query& query) const
+	PUGI_IMPL_FN xpath_node_set xml_node::select_nodes(const xpath_query& query) const
 	{
 		return query.evaluate_node_set(*this);
 	}
 
-	PUGI__FN xpath_node xml_node::select_single_node(const char_t* query, xpath_variable_set* variables) const
+	PUGI_IMPL_FN xpath_node xml_node::select_single_node(const char_t* query, xpath_variable_set* variables) const
 	{
 		xpath_query q(query, variables);
 		return q.evaluate_node(*this);
 	}
 
-	PUGI__FN xpath_node xml_node::select_single_node(const xpath_query& query) const
+	PUGI_IMPL_FN xpath_node xml_node::select_single_node(const xpath_query& query) const
 	{
 		return query.evaluate_node(*this);
 	}
@@ -13089,51 +13480,55 @@ namespace pugi
 #	pragma option pop
 #endif
 
+#if defined(_MSC_VER) && defined(__c2__)
+#	pragma clang diagnostic pop
+#endif
+
+#if defined(__clang__)
+#	pragma clang diagnostic pop
+#endif
+
 // Intel C++ does not properly keep warning state for function templates,
 // so popping warning state at the end of translation unit leads to warnings in the middle.
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #	pragma warning(pop)
 #endif
 
-#if defined(_MSC_VER) && defined(__c2__)
-#	pragma clang diagnostic pop
-#endif
-
 // Undefine all local macros (makes sure we're not leaking macros in header-only mode)
-#undef PUGI__NO_INLINE
-#undef PUGI__UNLIKELY
-#undef PUGI__STATIC_ASSERT
-#undef PUGI__DMC_VOLATILE
-#undef PUGI__UNSIGNED_OVERFLOW
-#undef PUGI__MSVC_CRT_VERSION
-#undef PUGI__SNPRINTF
-#undef PUGI__NS_BEGIN
-#undef PUGI__NS_END
-#undef PUGI__FN
-#undef PUGI__FN_NO_INLINE
-#undef PUGI__GETHEADER_IMPL
-#undef PUGI__GETPAGE_IMPL
-#undef PUGI__GETPAGE
-#undef PUGI__NODETYPE
-#undef PUGI__IS_CHARTYPE_IMPL
-#undef PUGI__IS_CHARTYPE
-#undef PUGI__IS_CHARTYPEX
-#undef PUGI__ENDSWITH
-#undef PUGI__SKIPWS
-#undef PUGI__OPTSET
-#undef PUGI__PUSHNODE
-#undef PUGI__POPNODE
-#undef PUGI__SCANFOR
-#undef PUGI__SCANWHILE
-#undef PUGI__SCANWHILE_UNROLL
-#undef PUGI__ENDSEG
-#undef PUGI__THROW_ERROR
-#undef PUGI__CHECK_ERROR
+#undef PUGI_IMPL_NO_INLINE
+#undef PUGI_IMPL_UNLIKELY
+#undef PUGI_IMPL_STATIC_ASSERT
+#undef PUGI_IMPL_DMC_VOLATILE
+#undef PUGI_IMPL_UNSIGNED_OVERFLOW
+#undef PUGI_IMPL_MSVC_CRT_VERSION
+#undef PUGI_IMPL_SNPRINTF
+#undef PUGI_IMPL_NS_BEGIN
+#undef PUGI_IMPL_NS_END
+#undef PUGI_IMPL_FN
+#undef PUGI_IMPL_FN_NO_INLINE
+#undef PUGI_IMPL_GETHEADER_IMPL
+#undef PUGI_IMPL_GETPAGE_IMPL
+#undef PUGI_IMPL_GETPAGE
+#undef PUGI_IMPL_NODETYPE
+#undef PUGI_IMPL_IS_CHARTYPE_IMPL
+#undef PUGI_IMPL_IS_CHARTYPE
+#undef PUGI_IMPL_IS_CHARTYPEX
+#undef PUGI_IMPL_ENDSWITH
+#undef PUGI_IMPL_SKIPWS
+#undef PUGI_IMPL_OPTSET
+#undef PUGI_IMPL_PUSHNODE
+#undef PUGI_IMPL_POPNODE
+#undef PUGI_IMPL_SCANFOR
+#undef PUGI_IMPL_SCANWHILE
+#undef PUGI_IMPL_SCANWHILE_UNROLL
+#undef PUGI_IMPL_ENDSEG
+#undef PUGI_IMPL_THROW_ERROR
+#undef PUGI_IMPL_CHECK_ERROR
 
 #endif
 
 /**
- * Copyright (c) 2006-2024 Arseny Kapoulkine
+ * Copyright (c) 2006-2025 Arseny Kapoulkine
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/contrib/pugixml/src/pugixml.hpp
+++ b/contrib/pugixml/src/pugixml.hpp
@@ -1,7 +1,7 @@
 /**
- * pugixml parser - version 1.13
+ * pugixml parser - version 1.15
  * --------------------------------------------------------
- * Copyright (c) 2006-2024, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
+ * Copyright (C) 2006-2025, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
  * Report bugs and download new versions at https://pugixml.org/
  *
  * This library is distributed under the MIT License. See notice at the end
@@ -14,7 +14,7 @@
 // Define version macro; evaluates to major * 1000 + minor * 10 + patch so that it's safe to use in less-than comparisons
 // Note: pugixml used major * 100 + minor * 10 + patch format up until 1.9 (which had version identifier 190); starting from pugixml 1.10, the minor version number is two digits
 #ifndef PUGIXML_VERSION
-#	define PUGIXML_VERSION 1130 // 1.13
+#	define PUGIXML_VERSION 1150 // 1.15
 #endif
 
 // Include user configuration file (this can define various configuration macros)
@@ -36,6 +36,20 @@
 #	include <iterator>
 #	include <iosfwd>
 #	include <string>
+#endif
+
+// Check if std::string_view is available
+#if !defined(PUGIXML_HAS_STRING_VIEW) && !defined(PUGIXML_NO_STL)
+#	if __cplusplus >= 201703L
+#		define PUGIXML_HAS_STRING_VIEW
+#	elif defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#		define PUGIXML_HAS_STRING_VIEW
+#	endif
+#endif
+
+// Include string_view if appropriate
+#ifdef PUGIXML_HAS_STRING_VIEW
+#	include <string_view>
 #endif
 
 // Macro for deprecated features
@@ -82,14 +96,14 @@
 #	endif
 #endif
 
-// If C++ is 2011 or higher, add 'noexcept' specifiers
+// If C++ is 2011 or higher, use 'noexcept' specifiers
 #ifndef PUGIXML_NOEXCEPT
 #	if __cplusplus >= 201103
 #		define PUGIXML_NOEXCEPT noexcept
 #	elif defined(_MSC_VER) && _MSC_VER >= 1900
 #		define PUGIXML_NOEXCEPT noexcept
 #	else
-#		define PUGIXML_NOEXCEPT
+#		define PUGIXML_NOEXCEPT throw()
 #	endif
 #endif
 
@@ -138,7 +152,12 @@ namespace pugi
 
 #ifndef PUGIXML_NO_STL
 	// String type used for operations that work with STL string; depends on PUGIXML_WCHAR_MODE
-	typedef std::basic_string<PUGIXML_CHAR, std::char_traits<PUGIXML_CHAR>, std::allocator<PUGIXML_CHAR> > string_t;
+	typedef std::basic_string<PUGIXML_CHAR> string_t;
+#endif
+
+#ifdef PUGIXML_HAS_STRING_VIEW
+	// String view type used for operations that can work with a length delimited string; depends on PUGIXML_WCHAR_MODE
+	typedef std::basic_string_view<PUGIXML_CHAR> string_view_t;
 #endif
 }
 
@@ -212,6 +231,10 @@ namespace pugi
 	// the document; this flag is only recommended for parsing documents with many PCDATA nodes in memory-constrained environments.
 	// This flag is off by default.
 	const unsigned int parse_embed_pcdata = 0x2000;
+
+	// This flag determines whether determines whether the the two pcdata should be merged or not, if no intermediatory data are parsed in the document.
+	// This flag is off by default.
+	const unsigned int parse_merge_pcdata = 0x4000;
 
 	// The default parsing mode.
 	// Elements, PCDATA and CDATA sections are added to the DOM tree, character/reference entities are expanded,
@@ -324,7 +347,7 @@ namespace pugi
 	class PUGIXML_CLASS xml_writer
 	{
 	public:
-		virtual ~xml_writer() {}
+		virtual ~xml_writer();
 
 		// Write memory chunk into stream/file/whatever
 		virtual void write(const void* data, size_t size) = 0;
@@ -349,14 +372,14 @@ namespace pugi
 	{
 	public:
 		// Construct writer from an output stream object
-		xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream);
-		xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream);
+		xml_writer_stream(std::basic_ostream<char>& stream);
+		xml_writer_stream(std::basic_ostream<wchar_t>& stream);
 
 		virtual void write(const void* data, size_t size) PUGIXML_OVERRIDE;
 
 	private:
-		std::basic_ostream<char, std::char_traits<char> >* narrow_stream;
-		std::basic_ostream<wchar_t, std::char_traits<wchar_t> >* wide_stream;
+		std::basic_ostream<char>* narrow_stream;
+		std::basic_ostream<wchar_t>* wide_stream;
 	};
 	#endif
 
@@ -392,7 +415,7 @@ namespace pugi
 		bool operator<=(const xml_attribute& r) const;
 		bool operator>=(const xml_attribute& r) const;
 
-		// Check if attribute is empty
+		// Check if attribute is empty (null)
 		bool empty() const;
 
 		// Get attribute name/value, or "" if attribute is empty
@@ -418,8 +441,15 @@ namespace pugi
 
 		// Set attribute name/value (returns false if attribute is empty or there is not enough memory)
 		bool set_name(const char_t* rhs);
-		bool set_value(const char_t* rhs, size_t sz);
+		bool set_name(const char_t* rhs, size_t size);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool set_name(string_view_t rhs);
+	#endif
 		bool set_value(const char_t* rhs);
+		bool set_value(const char_t* rhs, size_t size);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool set_value(string_view_t rhs);
+	#endif
 
 		// Set attribute value with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set_value(int rhs);
@@ -446,6 +476,10 @@ namespace pugi
 		xml_attribute& operator=(double rhs);
 		xml_attribute& operator=(float rhs);
 		xml_attribute& operator=(bool rhs);
+
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_attribute& operator=(string_view_t rhs);
+	#endif
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_attribute& operator=(long long rhs);
@@ -502,7 +536,7 @@ namespace pugi
 		bool operator<=(const xml_node& r) const;
 		bool operator>=(const xml_node& r) const;
 
-		// Check if node is empty.
+		// Check if node is empty (null)
 		bool empty() const;
 
 		// Get node type
@@ -541,9 +575,18 @@ namespace pugi
 		xml_attribute attribute(const char_t* name) const;
 		xml_node next_sibling(const char_t* name) const;
 		xml_node previous_sibling(const char_t* name) const;
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_node child(string_view_t name) const;
+		xml_attribute attribute(string_view_t name) const;
+		xml_node next_sibling(string_view_t name) const;
+		xml_node previous_sibling(string_view_t name) const;
+	#endif
 
 		// Get attribute, starting the search from a hint (and updating hint so that searching for a sequence of attributes is fast)
 		xml_attribute attribute(const char_t* name, xml_attribute& hint) const;
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_attribute attribute(string_view_t name, xml_attribute& hint) const;
+	#endif
 
 		// Get child value of current node; that is, value of the first child node of type PCDATA/CDATA
 		const char_t* child_value() const;
@@ -553,14 +596,27 @@ namespace pugi
 
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
 		bool set_name(const char_t* rhs);
-		bool set_value(const char_t* rhs, size_t sz);
+		bool set_name(const char_t* rhs, size_t size);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool set_name(string_view_t rhs);
+	#endif
 		bool set_value(const char_t* rhs);
+		bool set_value(const char_t* rhs, size_t size);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool set_value(string_view_t rhs);
+	#endif
 
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_attribute(const char_t* name);
 		xml_attribute prepend_attribute(const char_t* name);
 		xml_attribute insert_attribute_after(const char_t* name, const xml_attribute& attr);
 		xml_attribute insert_attribute_before(const char_t* name, const xml_attribute& attr);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_attribute append_attribute(string_view_t name);
+		xml_attribute prepend_attribute(string_view_t name);
+		xml_attribute insert_attribute_after(string_view_t name, const xml_attribute& attr);
+		xml_attribute insert_attribute_before(string_view_t name, const xml_attribute& attr);
+	#endif
 
 		// Add a copy of the specified attribute. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_copy(const xml_attribute& proto);
@@ -579,6 +635,12 @@ namespace pugi
 		xml_node prepend_child(const char_t* name);
 		xml_node insert_child_after(const char_t* name, const xml_node& node);
 		xml_node insert_child_before(const char_t* name, const xml_node& node);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_node append_child(string_view_t name);
+		xml_node prepend_child(string_view_t name);
+		xml_node insert_child_after(string_view_t, const xml_node& node);
+		xml_node insert_child_before(string_view_t name, const xml_node& node);
+	#endif
 
 		// Add a copy of the specified node as a child. Returns added node, or empty node on errors.
 		xml_node append_copy(const xml_node& proto);
@@ -595,6 +657,9 @@ namespace pugi
 		// Remove specified attribute
 		bool remove_attribute(const xml_attribute& a);
 		bool remove_attribute(const char_t* name);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool remove_attribute(string_view_t name);
+	#endif
 
 		// Remove all attributes
 		bool remove_attributes();
@@ -602,6 +667,9 @@ namespace pugi
 		// Remove specified child
 		bool remove_child(const xml_node& n);
 		bool remove_child(const char_t* name);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool remove_child(string_view_t name);
+	#endif
 
 		// Remove all children
 		bool remove_children();
@@ -694,8 +762,8 @@ namespace pugi
 
 	#ifndef PUGIXML_NO_STL
 		// Print subtree to stream
-		void print(std::basic_ostream<char, std::char_traits<char> >& os, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default, xml_encoding encoding = encoding_auto, unsigned int depth = 0) const;
-		void print(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& os, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default, unsigned int depth = 0) const;
+		void print(std::basic_ostream<char>& os, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default, xml_encoding encoding = encoding_auto, unsigned int depth = 0) const;
+		void print(std::basic_ostream<wchar_t>& os, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default, unsigned int depth = 0) const;
 	#endif
 
 		// Child nodes iterators
@@ -712,8 +780,11 @@ namespace pugi
 
 		// Range-based for support
 		xml_object_range<xml_node_iterator> children() const;
-		xml_object_range<xml_named_node_iterator> children(const char_t* name) const;
 		xml_object_range<xml_attribute_iterator> attributes() const;
+
+		// Range-based for support for all children with the specified name
+		// Note: name pointer must have a longer lifetime than the returned object; be careful with passing temporaries!
+		xml_object_range<xml_named_node_iterator> children(const char_t* name) const;
 
 		// Get node offset in parsed file/string (in char_t units) for debugging purposes
 		ptrdiff_t offset_debug() const;
@@ -755,7 +826,7 @@ namespace pugi
 		// Borland C++ workaround
 		bool operator!() const;
 
-		// Check if text object is empty
+		// Check if text object is empty (null)
 		bool empty() const;
 
 		// Get text, or "" if object is empty
@@ -779,8 +850,11 @@ namespace pugi
 		bool as_bool(bool def = false) const;
 
 		// Set text (returns false if object is empty or there is not enough memory)
-		bool set(const char_t* rhs, size_t sz);
 		bool set(const char_t* rhs);
+		bool set(const char_t* rhs, size_t size);
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		bool set(string_view_t rhs);
+	#endif
 
 		// Set text with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set(int rhs);
@@ -807,6 +881,10 @@ namespace pugi
 		xml_text& operator=(double rhs);
 		xml_text& operator=(float rhs);
 		xml_text& operator=(bool rhs);
+
+	#ifdef PUGIXML_HAS_STRING_VIEW
+		xml_text& operator=(string_view_t rhs);
+	#endif
 
 	#ifdef PUGIXML_HAS_LONG_LONG
 		xml_text& operator=(long long rhs);
@@ -927,6 +1005,7 @@ namespace pugi
 		xml_named_node_iterator();
 
 		// Construct an iterator which points to the specified node
+		// Note: name pointer is stored in the iterator and must have a longer lifetime than iterator itself
 		xml_named_node_iterator(const xml_node& node, const char_t* name);
 
 		// Iterator operators
@@ -1062,8 +1141,8 @@ namespace pugi
 
 	#ifndef PUGIXML_NO_STL
 		// Load document from stream.
-		xml_parse_result load(std::basic_istream<char, std::char_traits<char> >& stream, unsigned int options = parse_default, xml_encoding encoding = encoding_auto);
-		xml_parse_result load(std::basic_istream<wchar_t, std::char_traits<wchar_t> >& stream, unsigned int options = parse_default);
+		xml_parse_result load(std::basic_istream<char>& stream, unsigned int options = parse_default, xml_encoding encoding = encoding_auto);
+		xml_parse_result load(std::basic_istream<wchar_t>& stream, unsigned int options = parse_default);
 	#endif
 
 		// (deprecated: use load_string instead) Load document from zero-terminated string. No encoding conversions are applied.
@@ -1092,8 +1171,8 @@ namespace pugi
 
 	#ifndef PUGIXML_NO_STL
 		// Save XML document to stream (semantics is slightly different from xml_node::print, see documentation for details).
-		void save(std::basic_ostream<char, std::char_traits<char> >& stream, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default, xml_encoding encoding = encoding_auto) const;
-		void save(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default) const;
+		void save(std::basic_ostream<char>& stream, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default, xml_encoding encoding = encoding_auto) const;
+		void save(std::basic_ostream<wchar_t>& stream, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default) const;
 	#endif
 
 		// Save XML to file
@@ -1304,7 +1383,7 @@ namespace pugi
 		explicit xpath_exception(const xpath_parse_result& result);
 
 		// Get error message
-		virtual const char* what() const throw() PUGIXML_OVERRIDE;
+		virtual const char* what() const PUGIXML_NOEXCEPT PUGIXML_OVERRIDE;
 
 		// Get parse result
 		const xpath_parse_result& result() const;
@@ -1429,12 +1508,12 @@ namespace pugi
 
 #ifndef PUGIXML_NO_STL
 	// Convert wide string to UTF8
-	std::basic_string<char, std::char_traits<char>, std::allocator<char> > PUGIXML_FUNCTION as_utf8(const wchar_t* str);
-	std::basic_string<char, std::char_traits<char>, std::allocator<char> > PUGIXML_FUNCTION as_utf8(const std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >& str);
+	std::basic_string<char> PUGIXML_FUNCTION as_utf8(const wchar_t* str);
+	std::basic_string<char> PUGIXML_FUNCTION as_utf8(const std::basic_string<wchar_t>& str);
 
 	// Convert UTF8 to wide string
-	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > PUGIXML_FUNCTION as_wide(const char* str);
-	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > PUGIXML_FUNCTION as_wide(const std::basic_string<char, std::char_traits<char>, std::allocator<char> >& str);
+	std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const char* str);
+	std::basic_string<wchar_t> PUGIXML_FUNCTION as_wide(const std::basic_string<char>& str);
 #endif
 
 	// Memory allocation function interface; returns pointer to allocated memory or NULL on failure
@@ -1481,7 +1560,7 @@ namespace std
 #endif
 
 /**
- * Copyright (c) 2006-2024 Arseny Kapoulkine
+ * Copyright (c) 2006-2025 Arseny Kapoulkine
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/test/unit/Common/utParsingUtils.cpp
+++ b/test/unit/Common/utParsingUtils.cpp
@@ -60,7 +60,7 @@ TEST_F(utParsingUtils, parseFloatsStringTest) {
     for (float i : floatArray) {
         float value = 0.0f;
         SkipSpacesAndLineEnd(&content, end);
-        content = fast_atoreal_move<ai_real>(content, value);
+        content = fast_atoreal_move(content, value);
         EXPECT_FLOAT_EQ(value, i);
     }
 }


### PR DESCRIPTION
…element count tracking (closes #6011)

description:
- The current implementation has faulty reallocation logic when parsing a CSM file
- Issue 1
    - https://github.com/assimp/assimp/blob/4ad1d2aa3086517816716a50aa122342806736f9/code/AssetLib/CSM/CSMLoader.cpp#L205
    - By assigning s->mNumPositionKeys = alloc*2 right before resizing the buffer, making s->mNumPositionKeys equivalent to the max number of aiVectorKey that can be stored in s->mPositionKeys
    - the code later attempts to get the next write location by doing: aiVectorKey* sub = s->mPositionKeys + s->mNumPositionKeys;
    - this points to the end of the array, not after the last element in the array
- Issue 2
    - https://github.com/assimp/assimp/blob/4ad1d2aa3086517816716a50aa122342806736f9/code/AssetLib/CSM/CSMLoader.cpp#L178-L184
    - if the CSM file does not declare last frame data, then mPositionKeys will never be initialized

fix:
- we preserve s->mNumPositionKeys to still contain the actual number of aiVectorKeys and ensure that we will not write out of bounds
- we initialize mPositionKeys with a default value and if we find last frame info, we just re-initialize it